### PR TITLE
Rename variables to help with code maintenance.

### DIFF
--- a/include/GribRecord.h
+++ b/include/GribRecord.h
@@ -198,7 +198,25 @@ class GribRecord
         // Value for one point interpolated
         double  getInterpolatedValue(double px, double py, bool numericalInterpolation=true, bool dir=false) const;
 
-        // Value for polar interpolation of vectors
+        /**
+         * Interpolates vector values from two GRIB records at a specified point.
+         *
+         * This function calculates the magnitude and angle of a vector by interpolating 
+         * X and Y component values from two GRIB records at the given geographic coordinates.
+         * It handles cases where the requested point might cross the date line by adjusting 
+         * the longitude if needed.
+         *
+         * @param M [out] Magnitude of the interpolated vector (calculated from X and Y components)
+         * @param A [out] Angle of the interpolated vector in degrees (0-360, meteorological convention)
+         * @param GRX The GRIB record containing X component values (e.g., U wind component)
+         * @param GRY The GRIB record containing Y component values (e.g., V wind component)
+         * @param px Longitude of the point to interpolate at (degrees)
+         * @param py Latitude of the point to interpolate at (degrees)
+         * @param numericalInterpolation If true, uses bilinear interpolation; if false, uses nearest neighbor
+         *
+         * @return true if interpolation was successful, false if the point is outside map boundaries
+         *         or if insufficient valid data points exist for interpolation
+         */
         static bool getInterpolatedValues(double &M, double &A,
                                           const GribRecord *GRX, const GribRecord *GRY,
                                           double px, double py, bool numericalInterpolation=true);

--- a/include/PlotDialog.h
+++ b/include/PlotDialog.h
@@ -35,45 +35,88 @@
 class weather_routing_pi;
 class WeatherRouting;
 
-class PlotDialog : public PlotDialogBase
-{
+class PlotDialog : public PlotDialogBase {
 public:
+  PlotDialog(WeatherRouting& weatherrouting);
+  ~PlotDialog();
 
-    PlotDialog( WeatherRouting &weatherrouting );
-    ~PlotDialog();
-
-    void SetRouteMapOverlay(RouteMapOverlay *routemapoverlay);
-
-private:
-    enum Variable { SPEED_OVER_GROUND, COURSE_OVER_GROUND, SPEED_OVER_WATER,
-                    COURSE_OVER_WATER, WIND_VELOCITY, WIND_DIRECTION, WIND_COURSE,
-                    WIND_VELOCITY_GROUND, WIND_DIRECTION_GROUND, WIND_COURSE_GROUND,
-                    APPARENT_WIND_SPEED, APPARENT_WIND_ANGLE, WIND_GUST,
-                    CURRENT_VELOCITY, CURRENT_DIRECTION, SIG_WAVE_HEIGHT, TACKS };
-
-    void OnMouseEventsPlot( wxMouseEvent& event );
-    void OnPaintPlot( wxPaintEvent& event );
-    void OnSizePlot( wxSizeEvent& event ) { m_PlotWindow->Refresh(); }
-    void OnUpdatePlot( wxScrollEvent& event ) { m_PlotWindow->Refresh(); }
-    void OnUpdatePlotVariable( wxCommandEvent& event ) { GetScale(); m_PlotWindow->Refresh(); }
-    void OnUpdateRoute( wxCommandEvent& event );
-    void OnUpdateUI( wxUpdateUIEvent& event );
+  void SetRouteMapOverlay(RouteMapOverlay* routemapoverlay);
 
 private:
+  /**
+   * Navigation and weather variables used in route calculations.
+   *
+   * This enum represents various navigation parameters related to vessel
+   * movement, wind conditions, and sea state that are used in weather routing
+   * calculations.
+   */
+  enum Variable {
+    /** Vessel's speed relative to the earth's surface in knots (SOG) */
+    SPEED_OVER_GROUND,
+    /** Vessel's direction of travel relative to the earth's surface in degrees
+       (COG) */
+    COURSE_OVER_GROUND,
+    /** Vessel's speed relative to the water in knots (STW) */
+    SPEED_OVER_WATER,
+    /** Vessel's direction of travel relative to the water in degrees (CTW) -
+       differs from heading by accounting for leeway */
+    COURSE_OVER_WATER,
+    /** Wind speed relative to the water's frame of reference in knots. */
+    WIND_VELOCITY,
+    /** Relative angle between vessel's course through water and the wind
+       direction in degrees. */
+    WIND_DIRECTION,
+    /** Absolute wind direction over water in degrees (meteorological, where
+       wind is coming FROM) */
+    WIND_COURSE,
+    /** True wind speed relative to the earth's surface in knots (TWS) */
+    WIND_VELOCITY_GROUND,
+    /** True Wind direction relative to the vessel's course over ground in degrees
+       (relative angle) */
+    WIND_DIRECTION_GROUND,
+    /** Absolute true wind direction in degrees relative to true north (TWD) -
+       meteorological, where wind is coming FROM */
+    WIND_COURSE_GROUND,
+    /** Wind speed as experienced by the vessel in knots (AWS) */
+    APPARENT_WIND_SPEED,
+    /** Angle between vessel heading and apparent wind in degrees (AWA) */
+    APPARENT_WIND_ANGLE,
+    /** Maximum wind speed in gusts in knots */
+    WIND_GUST,
+    /** Water current speed in knots */
+    CURRENT_VELOCITY,
+    /** Water current direction in degrees (from direction) */
+    CURRENT_DIRECTION,
+    /** Significant wave height in meters */
+    SIG_WAVE_HEIGHT,
+    /** Number of tacking maneuvers in a sailing route */
+    TACKS
+  };
 
-    double GetValue(PlotData &data, int var);
-    int GetType(int var);
-    void GetScale();
+  void OnMouseEventsPlot(wxMouseEvent& event);
+  void OnPaintPlot(wxPaintEvent& event);
+  void OnSizePlot(wxSizeEvent& event) { m_PlotWindow->Refresh(); }
+  void OnUpdatePlot(wxScrollEvent& event) { m_PlotWindow->Refresh(); }
+  void OnUpdatePlotVariable(wxCommandEvent& event) {
+    GetScale();
+    m_PlotWindow->Refresh();
+  }
+  void OnUpdateRoute(wxCommandEvent& event);
+  void OnUpdateUI(wxUpdateUIEvent& event);
 
-    wxDateTime m_StartTime;
+private:
+  double GetValue(PlotData& data, int var);
+  int GetType(int var);
+  void GetScale();
 
-    double m_mintime, m_maxtime;
-    double m_minvalue[3], m_maxvalue[3];
+  wxDateTime m_StartTime;
 
-    std::list<PlotData> m_PlotData;
+  double m_mintime, m_maxtime;
+  double m_minvalue[3], m_maxvalue[3];
 
-    WeatherRouting &m_WeatherRouting;
+  std::list<PlotData> m_PlotData;
 
+  WeatherRouting& m_WeatherRouting;
 };
 
 #endif

--- a/include/Polar.h
+++ b/include/Polar.h
@@ -26,89 +26,401 @@
 #include <vector>
 #include "PolygonRegion.h"
 
-struct SailingVMG
-{
-    enum { STARBOARD_UPWIND, PORT_UPWIND, STARBOARD_DOWNWIND, PORT_DOWNWIND};
-    float values[4];
+/**
+ * Stores optimal sailing angles for best Velocity Made Good (VMG) in different
+ * sailing directions. VMG represents the component of the boat's velocity in
+ * the upwind or downwind direction.
+ */
+struct SailingVMG {
+  /** Indexes for the values array representing different sailing directions. */
+  enum {
+    STARBOARD_UPWIND,    //!< Sailing upwind on starboard tack (0-90 degrees)
+    PORT_UPWIND,         //!< Sailing upwind on port tack (270-360 degrees)
+    STARBOARD_DOWNWIND,  //!< Sailing downwind on starboard tack (90-180
+                         //!< degrees)
+    PORT_DOWNWIND        //!< Sailing downwind on port tack (180-270 degrees)
+  };
+  /**
+   * Optimal sailing angles (in degrees) for maximum VMG in each sailing
+   * direction. These values represent the wind angles that produce the best
+   * progress toward or away from the wind direction.
+   */
+  float values[4];
 };
 
-struct PolarMeasurement
-{
-    PolarMeasurement(double v, double d, double vb, bool apparent=true);
-    double VW() const;
-    double W() const;
-    double VA, A, VB, eta;
+/**
+ * Represents a single performance measurement of a boat at specific wind
+ * conditions. Used for generating or refining polar diagrams from real-world or
+ * theoretical measurements.
+ */
+struct PolarMeasurement {
+  /**
+   * Constructor for creating a new measurement.
+   *
+   * @param windSpeed Wind speed (apparent or true depending on 'apparent'
+   * parameter)
+   * @param windAngle Wind angle (apparent or true depending on 'apparent'
+   * parameter)
+   * @param boatSpeed Boat speed in knots, as observed in the measurement.
+   * @param apparent If true, v and d are apparent wind values; if false, they
+   * are true wind values
+   */
+  PolarMeasurement(double windSpeed, double windAngle, double boatSpeed,
+                   bool apparent = true);
+  /**
+   * Calculate the true wind speed for this measurement.
+   *
+   * @return True wind speed in knots
+   */
+  double getTWS() const;
+  /**
+   * Calculate the true wind angle for this measurement.
+   *
+   * @return True wind angle in degrees
+   */
+  double getTWA() const;
+  double aws;  //!< Apparent wind speed in knots
+  double awa;  //!< Apparent wind angle in degrees
+  /** Boat speed (Speed Through Water) in knots, as observed in the measurement.
+   */
+  double stw;
+  /**
+   * This parameter represents the relationship between the apparent wind
+   * conditions and the resulting boat speed. Lower eta values indicate more
+   * efficient sailing performance (better conversion of wind energy to boat
+   * speed).
+   */
+  double eta;
 };
 
 class Boat;
 
 #define DEGREES 360
 
-class Polar
-{
+class Polar {
 public:
-    static double VelocityApparentWind(double VB, double W, double VW);
-    static double DirectionApparentWind(double VA, double VB, double W, double VW);
-    static double DirectionApparentWind(double VB, double W, double VW);
-    static double VelocityTrueWind(double VA, double VB, double W);
-    static double VelocityTrueWind2(double VA, double VB, double A);
+  /**
+   * Calculates the apparent wind speed.
+   *
+   * This function computes the apparent wind speed (AWS) that a vessel
+   * experiences, based on the vessel's speed through water and the
+   * water-relative wind.
+   * The calculation uses the law of cosines: c² = a² + b² * - 2ab·cos(C)
+   *
+   * @param stw Speed Through Water - the vessel's speed relative to the water
+   * in knots
+   * @param relativeWindAngle The angle between the vessel's course through
+   * water and the true wind direction (relative to water) in degrees.
+   * @param waterWindSpeed Wind speed relative to the water's frame of reference
+   * in knots
+   *
+   * @return Apparent Wind Speed (AWS) in knots
+   */
+  static double VelocityApparentWind(double stw, double relativeWindAngle,
+                                     double waterWindSpeed);
+  /**
+   * Calculates the apparent wind angle from true wind and boat velocity
+   * vectors.
+   *
+   * Uses the law of cosines to solve for the apparent wind angle. The apparent
+   * wind results from the vector addition of true wind and boat velocity
+   * vectors.
+   *
+   * @param aws Apparent wind speed in knots
+   * @param stw Boat speed (Speed Through Water) in knots
+   * @param W True wind angle in degrees
+   * @param VW True wind speed in knots
+   * @return Apparent wind angle in degrees:
+   *         - Returns 0 if aws is 0 (apparent wind direction undefined)
+   *         - Returns W if stw is 0 (no boat motion, apparent = true wind)
+   *         - Otherwise returns calculated angle accounting for both vectors
+   */
+  static double DirectionApparentWind(double aws, double stw, double W,
+                                      double VW);
+  /**
+   * Calculates the apparent wind angle from true wind and boat velocity
+   * vectors.
+   *
+   * @param stw Boat speed (Speed Through Water) in knots
+   * @param W True wind angle in degrees
+   * @param VW True wind speed in knots
+   * @return Apparent wind angle in degrees
+   */
+  static double DirectionApparentWind(double stw, double W, double VW);
+  /**
+   * Calculates true wind speed using the law of cosines given apparent wind and
+   * true wind angle.
+   *
+   * @param aws Apparent wind speed in knots
+   * @param stw Boat speed (Speed Through Water) in knots
+   * @param W True wind angle in degrees
+   * @return True wind speed in knots
+   * @note May sometimes have two mathematically possible solutions
+   */
+  static double VelocityTrueWind(double aws, double stw, double W);
+  /**
+   * Alternative method to calculate true wind speed using apparent wind angle
+   * instead of true wind angle.
+   *
+   * Uses the law of cosines in a different configuration than
+   * VelocityTrueWind().
+   *
+   * @param aws Apparent wind speed in knots
+   * @param stw Boat speed (Speed Through Water) in knots
+   * @param A Apparent wind angle in degrees
+   * @return True wind speed in knots
+   */
+  static double VelocityTrueWind2(double aws, double stw, double A);
 
-    Polar();
+  Polar();
 
-    bool Open(const wxString &filename, wxString &message);
-    bool Save(const wxString &filename);
+  bool Open(const wxString& filename, wxString& message);
+  bool Save(const wxString& filename);
 
-    wxString FileName;
+  wxString FileName;
 
-    void OptimizeTackingSpeeds();
-    void ClosestVWi(double VW, int &VW1i, int &VW2i);
+  void OptimizeTackingSpeeds();
+  void ClosestVWi(double VW, int& VW1i, int& VW2i);
 
-    double Speed(double W, double VW, bool bound=false, bool optimize_tacking=false);
-    double SpeedAtApparentWindDirection(double A, double VW, double *pW=0);
-    double SpeedAtApparentWindSpeed(double W, double VA);
-    double SpeedAtApparentWind(double A, double VA, double *pW=0);
+  /**
+   * Calculate the boat speed based on the wind angle and wind speed using polar
+   * data.
+   *
+   * The return value is strictly based on the polar data and does not consider
+   * any other factors such as current. This is the theoretical maximum boat
+   * speed for the given wind conditions.
+   *
+   * @param polarAngle The wind angle in degrees relative to the boat heading
+   * (0° = head to wind, 90° = beam reach, 180° = running). Values above 180°
+   * are mirrored as the polar is assumed symmetric.
+   * @param tws The true wind speed in knots.
+   * @param bound If true, returns NAN when wind speed is outside the range
+   * defined in the polar data. If false, extrapolates the boat speed when wind
+   * speed is outside the polar data range.
+   * @param optimize_tacking If true, calculates the optimal VMG angle for
+   * upwind sailing and returns the corresponding speed projected onto the
+   * requested course.
+   * @return The boat speed in knots, or NAN if the angle is in a no-go zone or
+   * other calculation constraints.
+   */
+  double Speed(double polarAngle, double tws, bool bound = false,
+               bool optimize_tacking = false);
+  /**
+   * Iteratively solves for boat speed given a target apparent wind direction.
+   *
+   * Uses an iterative approach to find the boat speed and true wind angle that
+   * would result in the specified apparent wind angle. The solver adjusts boat
+   * speed and recalculates apparent wind until convergence.
+   *
+   * @param awa Target apparent wind angle in degrees
+   * @param tws True wind speed in knots
+   * @param pTWA Optional pointer to store the resulting true wind angle in
+   * degrees
+   * @return Boat speed in knots, or NAN if no convergence after 256 iterations
+   */
+  double SpeedAtApparentWindDirection(double awa, double tws, double* pTWA = 0);
+  /**
+   * Iteratively solves for boat speed given a target apparent wind speed.
+   *
+   * Uses an iterative approach to find the boat speed and true wind speed that
+   * would result in the specified apparent wind speed at the given true wind
+   * angle.
+   *
+   * @param twa True wind angle in degrees
+   * @param aws Target apparent wind speed in knots
+   * @return Boat speed in knots, or NAN if no convergence after 256 iterations
+   */
+  double SpeedAtApparentWindSpeed(double twa, double aws);
+  /**
+   * Iteratively solves for boat speed given both apparent wind angle and speed.
+   *
+   * Uses an iterative approach to find the boat speed and true wind conditions
+   * that would result in both the specified apparent wind angle and speed. This
+   * combines the functionality of SpeedAtApparentWindDirection and
+   * SpeedAtApparentWindSpeed.
+   *
+   * @param awa Target apparent wind angle in degrees
+   * @param aws Target apparent wind speed in knots
+   * @param pTWA Optional pointer to store the resulting true wind angle in
+   * degrees
+   * @return Boat speed in knots, or NAN if no convergence after 256 iterations
+   */
+  double SpeedAtApparentWind(double awa, double aws, double* pTWA = 0);
 
-    double MinDegreeStep() { return degree_steps[0]; }
+  /**
+   * Gets the smallest wind angle (relative to boat heading) in the polar data.
+   *
+   * This represents the closest angle to directly upwind that has performance
+   * data, typically defining the minimum pointing angle (tacking angle) for the
+   * boat.
+   *
+   * @return The minimum wind angle in degrees from the polar data
+   */
+  double MinDegreeStep() { return degree_steps[0]; }
 
-    SailingVMG GetVMGTrueWind(double VW);
-    SailingVMG GetVMGApparentWind(double VA);
+  /**
+   * Gets optimal VMG angles for a given true wind speed.
+   *
+   * Interpolates between the pre-calculated VMG angles in the polar data
+   * to find optimal angles for the specified wind speed.
+   *
+   * @param tws The true wind speed in knots
+   * @return SailingVMG containing optimal angles for each point of sail:
+   *         - STARBOARD_UPWIND: Best upwind angle on starboard
+   *         - PORT_UPWIND: Best upwind angle on port
+   *         - STARBOARD_DOWNWIND: Best downwind angle on starboard
+   *         - PORT_DOWNWIND: Best downwind angle on port
+   *         Values will be NAN if wind speed is outside polar range
+   */
+  SailingVMG GetVMGTrueWind(double tws);
+  /**
+   * Calculates optimal VMG angles for a given apparent wind speed.
+   *
+   * For each of the four modes (upwind/downwind on port/starboard),
+   * iteratively finds the true wind conditions that would result in
+   * the specified apparent wind speed and give the best VMG.
+   *
+   * @param aws The apparent wind speed in knots
+   * @return SailingVMG containing optimal angles for each point of sail:
+   *         - STARBOARD_UPWIND: Best upwind angle on starboard
+   *         - PORT_UPWIND: Best upwind angle on port
+   *         - STARBOARD_DOWNWIND: Best downwind angle on starboard
+   *         - PORT_DOWNWIND: Best downwind angle on port
+   *         Values will be NAN if no valid solution found
+   */
+  SailingVMG GetVMGApparentWind(double aws);
 
-    double TrueWindSpeed(double VB, double W, double maxVW);
-    bool InterpolateSpeeds();
-    void UpdateSpeeds();
-    void UpdateDegreeStepLookup();
+  /**
+   * Calculates the true wind speed given boat speed and true wind angle.
+   *
+   * This function solves for the true wind speed that would result in the
+   * given boat speed at the specified true wind angle. It handles cases where
+   * the polar may be inverted at high wind speeds (where higher wind speeds
+   * result in lower boat speeds).
+   *
+   * @param stw Boat speed (Speed Through Water) in knots
+   * @param W True wind angle in degrees
+   * @param maxVW Maximum true wind speed to consider in knots
+   * @return The calculated true wind speed in knots, or NAN if no solution
+   * found
+   */
+  double TrueWindSpeed(double stw, double W, double maxVW);
+  bool InterpolateSpeeds();
+  void UpdateSpeeds();
+  void UpdateDegreeStepLookup();
 
-    bool InsideCrossOverContour(float H, float VW, bool optimize_tacking);
-    PolygonRegion CrossOverRegion;
+  bool InsideCrossOverContour(float H, float VW, bool optimize_tacking);
+  PolygonRegion CrossOverRegion;
 
-    void Generate(const std::list<PolarMeasurement> &measurements);
-    void AddDegreeStep(double twa);
-    void RemoveDegreeStep(int index);
-    void AddWindSpeed(double tws);
-    void RemoveWindSpeed(int index);
+  void Generate(const std::list<PolarMeasurement>& measurements);
+  void AddDegreeStep(double twa);
+  void RemoveDegreeStep(int index);
+  void AddWindSpeed(double tws);
+  void RemoveWindSpeed(int index);
 
-    double m_crossoverpercentage;
+  double m_crossoverpercentage;
 
 private:
-    friend class EditPolarDialog;
-    friend class BoatDialog;
+  friend class EditPolarDialog;
+  friend class BoatDialog;
 
-    void CalculateVMG(int speed);
+  /**
+   * Calculate and store the optimal VMG angles for a given wind speed entry in
+   * the polar.
+   *
+   * For each of the four sailing modes (upwind/downwind on port/starboard),
+   * finds the wind angle that gives the best progress directly upwind or
+   * downwind. Uses interpolation to find precise angles between polar data
+   * points.
+   *
+   * For symmetric polars (where data only goes to 180°), automatically mirrors
+   * the starboard values to port tack.
+   *
+   * @param VWi Index into wind_speeds array identifying which wind speed to
+   * calculate VMGs for.
+   */
+  void CalculateVMG(int VWi);
 
-    double AngleofAttackBoat(double A, double VA);
-    double VelocityBoat(double A, double VA);
+  /**
+   * Calculates the angle between the boat's heading and its course through
+   * water (leeway angle).
+   *
+   * The leeway angle occurs due to the sideways force of the sail being
+   * balanced by the keel/centerboard, causing the boat to move slightly
+   * sideways while sailing.
+   *
+   * @param awa The apparent wind angle in radians
+   * @param aws The apparent wind speed in knots
+   * @return The leeway angle in radians
+   *
+   * @note The current implementation returns 0. This feature is not yet
+   * implemented.
+   */
+  double AngleofAttackBoat(double awa, double aws);
 
-    struct SailingWindSpeed {
-        SailingWindSpeed(double nVW) : VW(nVW) {}
+  /**
+   * Calculates the theoretical boat speed using the sailboat transform model.
+   *
+   * Uses a simplified physical model based on the sailboat transform equations:
+   * stw = sin(awa/2) * sqrt(aws/eta)
+   *
+   * Where:
+   * - stw is the speed through water
+   * - awa is the apparent wind angle
+   * - aws is the apparent wind speed
+   * - eta is the efficiency coefficient (determines how much of the wind energy
+   * converts to boat speed)
+   *
+   * For wing-on-wing sailing (running downwind with sails on opposite sides),
+   * applies a speed bonus of up to 50% when sailing directly downwind.
+   *
+   * @param awa The apparent wind angle in radians
+   * @param aws The apparent wind speed in knots
+   * @return The calculated boat speed in knots, or 0 if:
+   *         - The apparent wind angle is less than the luffing angle (sails
+   * flapping)
+   *         - The efficiency coefficient (eta) is <= 0
+   */
+  double VelocityBoat(double awa, double aws);
 
-        float VW;
-        std::vector<float> speeds; // by degree_count
-        std::vector<float> orig_speeds; // by degree_count, from polar file
-        SailingVMG VMG;
-    }; // num_wind_speeds
-    bool VMGAngle(SailingWindSpeed &ws1, SailingWindSpeed &ws2, float VW, float &W);
+  /**
+   * Stores boat performance data for a specific wind speed.
+   */
+  struct SailingWindSpeed {
+    SailingWindSpeed(double nVW) : tws(nVW) {}
 
-    std::vector<SailingWindSpeed> wind_speeds;
-    std::vector<double> degree_steps;
-    unsigned int degree_step_index[DEGREES];
+    /** True wind speed in knots. */
+    float tws;
+    /** Boat speeds indexed by wind angle (matching degree_steps array). */
+    std::vector<float> speeds;
+    /** Original boat speeds from polar file before any modifications. (by
+     * degree_count) */
+    std::vector<float> orig_speeds;
+    /** Optimal VMG values for upwind and downwind sailing at this wind speed.
+     */
+    SailingVMG VMG;
+  };  // num_wind_speeds
+
+  /**
+   * Calculate optimal sailing angle for best Velocity Made Good (VMG) at a
+   * given wind speed.
+   *
+   * This function determines if a better VMG can be achieved by sailing at a
+   * different angle than the requested course. If so, it modifies the wind
+   * angle (W) to the optimal VMG angle. The Speed() function then uses this to
+   * calculate the projected boat speed on the original course.
+   *
+   * @param ws1 Lower wind speed bracket from polar data
+   * @param ws2 Upper wind speed bracket from polar data
+   * @param VW Target true wind speed to interpolate for
+   * @param W Reference to wind angle (modified if better VMG angle found)
+   * @return true if a better VMG angle was found and W was modified, false
+   * otherwise
+   */
+  bool VMGAngle(SailingWindSpeed& ws1, SailingWindSpeed& ws2, float VW,
+                float& W);
+
+  std::vector<SailingWindSpeed> wind_speeds;
+  std::vector<double> degree_steps;
+  unsigned int degree_step_index[DEGREES];
 };

--- a/src/EditPolarDialog.cpp
+++ b/src/EditPolarDialog.cpp
@@ -70,10 +70,10 @@ void EditPolarDialog::OnPolarGridChanged( wxGridEvent& event )
     wxString str = m_gPolar->GetCellValue(event.GetRow(), event.GetCol());
     if(str == "0")
         str = "";
-    double VB;
-    if(!str.ToDouble(&VB))
-        VB = NAN;
-    GetPolar()->wind_speeds[event.GetCol()].orig_speeds[event.GetRow()] = VB;
+    double stw;
+    if(!str.ToDouble(&stw))
+        stw = NAN;
+    GetPolar()->wind_speeds[event.GetCol()].orig_speeds[event.GetRow()] = stw;
     GetPolar()->UpdateSpeeds();
     m_BoatDialog->Refresh();
 }
@@ -132,19 +132,19 @@ void EditPolarDialog::OnAddMeasurement( wxCommandEvent& event )
 //        info.SetData(i);
     long idx = m_lMeasurements->InsertItem(info);
 
-    double windspeed, winddirection, VB;
+    double windspeed, winddirection, stw;
 
     m_tWindSpeed->GetValue().ToDouble(&windspeed);
     m_tWindDirection->GetValue().ToDouble(&winddirection);
 
-    m_tBoatSpeed->GetValue().ToDouble(&VB);
-    PolarMeasurement m(windspeed, winddirection, VB, m_rbApparentWind->GetValue());
+    m_tBoatSpeed->GetValue().ToDouble(&stw);
+    PolarMeasurement m(windspeed, winddirection, stw, m_rbApparentWind->GetValue());
 
-    m_lMeasurements->SetItem(idx, spTRUE_WIND_SPEED, dtos(m.VW()));
-    m_lMeasurements->SetItem(idx, spTRUE_WIND_DIRECTION, dtos(m.W()));
-    m_lMeasurements->SetItem(idx, spAPPARENT_WIND_SPEED, dtos(m.VA));
-    m_lMeasurements->SetItem(idx, spAPPARENT_WIND_DIRECTION, dtos(m.A));
-    m_lMeasurements->SetItem(idx, spBOAT_SPEED, dtos(m.VB));
+    m_lMeasurements->SetItem(idx, spTRUE_WIND_SPEED, dtos(m.getTWS()));
+    m_lMeasurements->SetItem(idx, spTRUE_WIND_DIRECTION, dtos(m.getTWA()));
+    m_lMeasurements->SetItem(idx, spAPPARENT_WIND_SPEED, dtos(m.aws));
+    m_lMeasurements->SetItem(idx, spAPPARENT_WIND_DIRECTION, dtos(m.awa));
+    m_lMeasurements->SetItem(idx, spBOAT_SPEED, dtos(m.stw));
     m_lMeasurements->SetItem(idx, spETA, dtos(m.eta));
 }
 
@@ -198,7 +198,7 @@ void EditPolarDialog::RebuildTrueWindSpeeds()
 
     for(unsigned int i = 0; i<GetPolar()->wind_speeds.size(); i++)
         m_lTrueWindSpeeds->Append
-            (wxString::Format(_T("%4.1f"), GetPolar()->wind_speeds[i].VW));
+            (wxString::Format(_T("%4.1f"), GetPolar()->wind_speeds[i].tws));
 }
 
 void EditPolarDialog::RebuildGrid()
@@ -219,7 +219,7 @@ void EditPolarDialog::RebuildGrid()
     m_gPolar->InsertCols(0, GetPolar()->wind_speeds.size());
     for(unsigned int i = 0; i<GetPolar()->wind_speeds.size(); i++) {
         m_gPolar->SetColLabelValue
-            ( i, wxString::Format(_T("%4.1f"), GetPolar()->wind_speeds[i].VW));
+            ( i, wxString::Format(_T("%4.1f"), GetPolar()->wind_speeds[i].tws));
 
         for(unsigned int j = 0; j<GetPolar()->degree_steps.size(); j++) {
             double v = GetPolar()->wind_speeds[i].orig_speeds[j];

--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -91,36 +91,64 @@ void PlotDialog::OnMouseEventsPlot( wxMouseEvent& event )
 double PlotDialog::GetValue(PlotData &data, int var)
 {
     switch(var) {
-    case SPEED_OVER_GROUND:            return data.VBG;
-    case COURSE_OVER_GROUND:           return positive_degrees(data.BG);
+    case SPEED_OVER_GROUND:            return data.sog;
+    case COURSE_OVER_GROUND:           return positive_degrees(data.cog);
 
-    case SPEED_OVER_WATER:             return data.VB;
-    case COURSE_OVER_WATER:            return positive_degrees(data.B);
+    case SPEED_OVER_WATER:             return data.stw;
+    case COURSE_OVER_WATER:            return positive_degrees(data.ctw);
 
     case WIND_VELOCITY:                return data.VW;
-    case WIND_DIRECTION:               return heading_resolve(data.B - data.W);
+    case WIND_DIRECTION:               return heading_resolve(data.ctw - data.W);
     case WIND_COURSE:                  return positive_degrees(data.W);
 
-    case WIND_VELOCITY_GROUND:         return data.VWG;
-    case WIND_DIRECTION_GROUND:        return heading_resolve(data.BG - data.WG);
-    case WIND_COURSE_GROUND:           return positive_degrees(data.WG);
+    case WIND_VELOCITY_GROUND:         return data.tws;
+    case WIND_DIRECTION_GROUND:        return heading_resolve(data.cog - data.twd);
+    case WIND_COURSE_GROUND:           return positive_degrees(data.twd);
 
    case APPARENT_WIND_SPEED:
-        return Polar::VelocityApparentWind(data.VB, GetValue(data, WIND_DIRECTION), data.VW);
+        return Polar::VelocityApparentWind(data.stw, GetValue(data, WIND_DIRECTION), data.VW);
     case APPARENT_WIND_ANGLE: {
-        return Polar::DirectionApparentWind (GetValue(data, APPARENT_WIND_SPEED), data.VB,
+        return Polar::DirectionApparentWind (GetValue(data, APPARENT_WIND_SPEED), data.stw,
                                               GetValue(data, WIND_DIRECTION), data.VW);
     case WIND_GUST: return data.VW_GUST;
     }
-    case CURRENT_VELOCITY: return data.VC;
-    case CURRENT_DIRECTION: return positive_degrees(data.C);
+    case CURRENT_VELOCITY: return data.currentSpeed;
+    case CURRENT_DIRECTION: return positive_degrees(data.currentDir);
     case SIG_WAVE_HEIGHT: return data.WVHT;
     case TACKS: return data.tacks;
     }
     return NAN;
 }
 
-enum Type {SPEED, COURSE, WIND_SPEED, WIND_DIRECTION, CURRENT_SPEED, CURRENT_DIRECTION, WAVE_HEIGHT, TACKS, WIND_COURSE, INVALID};
+/**
+ * Categories of navigation and weather data
+ *
+ * This enum represents general categories that group the more specific
+ * variables from the Variable enum. Used for processing and displaying
+ * related types of data.
+ */
+enum Type {
+    /** Vessel speed values (SOG, STW) */
+    SPEED,
+    /** Vessel course/heading values (COG, CTW) */
+    COURSE,
+    /** Wind speed values (true, apparent, gusts) */
+    WIND_SPEED,
+    /** Wind direction values (angles relative to vessel) */
+    WIND_DIRECTION,
+    /** Water current speed */
+    CURRENT_SPEED,
+    /** Water current direction */
+    CURRENT_DIRECTION,
+    /** Significant wave height */
+    WAVE_HEIGHT,
+    /** Tacking maneuvers count */
+    TACKS,
+    /** Absolute wind directions (meteorological) */
+    WIND_COURSE,
+    /** Invalid or undefined type */
+    INVALID
+};
 int PlotDialog::GetType(int var)
 {
     switch(var) {

--- a/src/SailboatTransform.cpp
+++ b/src/SailboatTransform.cpp
@@ -47,11 +47,11 @@ P = V P
        2
 P = k V
                  A    __
-FSx = k eta sin (-) \/VA
+FSx = k eta sin (-) \/aws
                  2
 
                  A    __
-FSy = k eta cos (-) \/VA
+FSy = k eta cos (-) \/aws
                  2
 
 FMx = sqrt(P k)
@@ -60,23 +60,23 @@ FMy = 0
 FKx = f (l s - k)
 FKy = - s j
 
-f = (FSx + FKx + FMx)dt = (k eta sin(A/2)*sqrt(VA) + f*(l*s-k)) dt
+f = (FSx + FKx + FMx)dt = (k eta sin(A/2)*sqrt(aws) + f*(l*s-k)) dt
 
 s = (FSy + FKy + FMy)dt
 
-s(inf) = k eta cos(A/2) sqrt(VA) / j
-f(inf) = eta sin(A/2) sqrt(VA) / (1 - l / j s(inf))
+s(inf) = k eta cos(A/2) sqrt(aws) / j
+f(inf) = eta sin(A/2) sqrt(aws) / (1 - l / j s(inf))
 
-         eta sin(A/2) sqrt(VA) + P
+         eta sin(A/2) sqrt(aws) + P
          ---------------------------
 f(inf) = 1 - l s(inf)
              -
              k
 
-(define (s eta A VA k j) (* k eta (cos (/ (deg2rad A) 2)) (sqrt VA) (/ j)))
-(define (f eta A VA l k j P) (/ (+ (* eta (sin (/ (deg2rad A) 2)) (sqrt VA)) P) (- 1 (* (/ l k) (s eta A VA k j)))))
-(define (aoa eta A VA l k j P) (rad2deg (atan (s eta A VA k j) (v eta A VA l k j P))))
-(define (BV eta A VA l k j P) (sqrt (+ (square (s eta A VA k j)) (square (f eta A VA l k j P)))))
+(define (s eta A aws k j) (* k eta (cos (/ (deg2rad A) 2)) (sqrt aws) (/ j)))
+(define (f eta A aws l k j P) (/ (+ (* eta (sin (/ (deg2rad A) 2)) (sqrt aws)) P) (- 1 (* (/ l k) (s eta A aws k j)))))
+(define (aoa eta A aws l k j P) (rad2deg (atan (s eta A aws k j) (v eta A aws l k j P))))
+(define (BV eta A aws l k j P) (sqrt (+ (square (s eta A aws k j)) (square (f eta A aws l k j P)))))
 aoa - angle of attack, direction keel is moving thru water
 aoa = atan2(s, f)
 BV
@@ -87,7 +87,7 @@ BV =   / 2    2
 */
 
 /* difference between direction we face and direction moving thru water */
-double BoatPlan::AngleofAttackBoat(double A, double VA)
+double BoatPlan::AngleofAttackBoat(double A, double aws)
 {
     return 0;
 }
@@ -95,7 +95,7 @@ double BoatPlan::AngleofAttackBoat(double A, double VA)
 /* speed of boat give apparent wind based on sailboat transform
 
  */
-double BoatPlan::VelocityBoat(double A, double VA)
+double BoatPlan::VelocityBoat(double A, double aws)
 {
     /* are we luffing? */
     if(A < deg2rad(luff_angle))
@@ -104,7 +104,7 @@ double BoatPlan::VelocityBoat(double A, double VA)
     if(eta <= 0) /* not ideal but prevent nans */
         return 0;
 
-    double val = sin(A/2) * sqrt(VA / eta);
+    double val = sin(A/2) * sqrt(aws / eta);
 
     /* for wing on wing, increase speed when wind is behind
        reaching 50% speed increase when dead downwind */
@@ -116,12 +116,12 @@ double BoatPlan::VelocityBoat(double A, double VA)
 
 /* Now that we can convert the wind speed in gribs correctly
    still need more coefficients.  We can run calculations
-   relative to motion thru water rather  than over ground
+   relative to motion thru water rather than over ground
    now.  Also the wind angle is the true bearing of the wind
    across the water.  The final boat direction is therefore
    shifted from this:
 
-   B  - boat direction thru water relative to north
+   ctw  - boat direction thru water relative to north
    W  - true wind direction (relative to vessel)
 
    optionally could include slippage here
@@ -131,9 +131,9 @@ double BoatPlan::VelocityBoat(double A, double VA)
    W  - true wind direction (relative to vessel)
    A  - apparent wind direction
    VW - true wind velocity
-   VA - apparent wind velocity
+   aws - apparent wind velocity
    eta - constant for boat efficiency (drag ratio)
-   VB - boat velocity
+   stw - boat velocity
 
                            Angle is W - A
                           /|
@@ -141,9 +141,9 @@ double BoatPlan::VelocityBoat(double A, double VA)
         Wind (VW)     /  |
                     /   /
   Angle is Pi-W   /    |
-sin(Pi-W)=sin(W) |    /  Apparent Wind (VA)
+sin(Pi-W)=sin(W) |    /  Apparent Wind (aws)
 cos(Pi-W)=-cos(W)|   |
-     Boat (VB)   |  /
+     Boat (stw)  |  /
                  | |
                  |/
               Angle is A
@@ -152,20 +152,20 @@ cos(Pi-W)=-cos(W)|   |
 
       sin A    sin W      sin W-A
       ----- = -------- = -------
-       VW        VA        VB
+       VW        aws        stw
 
             Law of cosines;
            ________________________
           /  2    2
-   VW =  / VA + VB - 2 VA VB cos(A)
+   VW =  / aws + stw - 2 aws stw cos(A)
        \/
            ________________________
           /  2    2
-   VA =  / VW + VB  + 2 VW VB cos(W)
+   aws =  / VW + stw  + 2 VW stw cos(W)
        \/
            ___________________________
           /  2    2
-   VB =  / VW + VA  - 2 VW VA cos(W-A)
+   stw =  / VW + aws  - 2 VW aws cos(W-A)
        \/
 
 Half angle formula:
@@ -180,27 +180,27 @@ Half angle formula:
    sin(W) sin(A) |  ----------  | = VW eta
                   \ sin(W - A) /
 
-   Reformulation in terms of VB instead of VW:
+   Reformulation in terms of stw instead of VW:
              2      
    sin(W) sin (A/2)
-   ---------------- = VB eta
+   ---------------- = stw eta
       sin(W - A)
 
-                      VB
+                      stw
     sin(W-A) = sin(W) --    Law of sines
-                      VA
+                      aws
 
            2          2
-     VA sin (A/2) = VB eta
+     aws sin (A/2) = stw eta
 
           ____________
          /      2     
-        / VA sin (A/2)
-VB =   /  -----------
+        / aws sin (A/2)
+stw =   /  -----------
      \/        eta
                  __
-           A    /VA
-VB =  sin (-)  /---
+           A    /aws
+stw =  sin (-)  /---
            2 \/ eta
 
 To decompose further to forces
@@ -218,34 +218,34 @@ V = integral(F / m)
   /
  /  0
                       __
-                A    /VA
-VB(inf) =  sin (-)  /---
+                A    /aws
+stw(inf) =  sin (-)  /---
                 2 \/ eta
 
 DF(inf) = BF(inf)
 DF(0) = 0
 BV(0) = 0
-DF(t) = DC VB(t)
+DF(t) = DC stw(t)
 
-        int(BF, 0..t) - DC int(VB, 0..t) = VB(t)
+        int(BF, 0..t) - DC int(stw, 0..t) = stw(t)
 
-pF(t) = BF(A(t), VA(t)) - DF(t)
-F(t) = BF(A(t), VA(t)) - DC VB(t)
+pF(t) = BF(A(t), aws(t)) - DF(t)
+F(t) = BF(A(t), aws(t)) - DC stw(t)
 
                       /                 /
                      |                 |
-                     |  BF(t) dt - DC  |  VB(t) dt = m VB(t)
+                     |  BF(t) dt - DC  |  stw(t) dt = m stw(t)
                      |                 |
                     /                 /
 
                    __
-             A    /VA
+             A    /aws
 BF = DC sin (-)  /---
              2 \/ eta
 
                       /                 /
                      |                 |
-                     |  BF(t) dt - DC  |  VB(t) dt = m VB(t)
+                     |  BF(t) dt - DC  |  stw(t) dt = m stw(t)
                      |                 |
                     /                 /
 
@@ -270,9 +270,9 @@ Since the steady state power required to move most boats is basically
 related to the square of the speed:
 
        2
-SP = VB
+SP = stw
 
-SC - Sail Coeffcient
+SC - Sail Coefficient
 SP - Sail Power
 SF - Sail Force
 MP - Motor Power
@@ -284,7 +284,7 @@ work  = force * distance
 velocity = distance / time
 
               2 A
-SP = SC VA sin (-)
+SP = SC aws sin (-)
                 2
            2 A
 SF = SC sin (-)
@@ -296,7 +296,7 @@ The steady state speed (time is infinity) for the boat's mass
 is irrelevant.  It is convenient to calculate but we are
 really after the position of the vessel via double integration.
 
-velocity of the air molecules is VA so the amount of wind
+velocity of the air molecules is aws so the amount of wind
 we can catch is related to the cross sectional area
 of the sail and direction of flow:
 
@@ -306,10 +306,10 @@ SC sin (-)
 
 This is, to say, this the the c
   2
-VB  = BP - 
+stw  = BP - 
 BP = SP
                2
-BP = 64 eta VA sin (A/2)   
+BP = 64 eta aws sin (A/2)   
 
 If P is negative then it is drag, or slows the boat by this amount.
 If the overall result is 
@@ -319,31 +319,31 @@ If the overall result is
 (define (rad2deg x) (* 180 (/ 3.14) x))
 (define (deg2rad x) (* 3.14 (/ 180) x))
 
-(define (compute-VB A VA eta P)
-  (let ((d (+ (* 64 (square eta) (square (sin (/ A 2))) VA) (* P (abs P)))))
+(define (compute-stw A aws eta P)
+  (let ((d (+ (* 64 (square eta) (square (sin (/ A 2))) aws) (* P (abs P)))))
     ((if (negative? d) - +) (sqrt (abs d)))))
 
-(define (compute-VA VW VB W) ; law of cosines
-   (let ((d (+ (square VW) (square VB) (* 2 VW VB (cos W)))))
+(define (compute-aws VW stw W) ; law of cosines
+   (let ((d (+ (square VW) (square stw) (* 2 VW stw (cos W)))))
      (if (negative? d) (error "d < 0 : " d) (sqrt d))))
       
-(define (compute-A VA VB VW W) ; law of sines
-   (if (zero? VA) 0
-     (if (zero? VB) W
-       (let ((d (/ (+ (square VA) (square VB) (- (square VW)))
-                   (* 2 VA VB))))
+(define (compute-A aws stw VW W) ; law of sines
+   (if (zero? aws) 0
+     (if (zero? stw) W
+       (let ((d (/ (+ (square aws) (square stw) (- (square VW)))
+                   (* 2 aws stw))))
             (cond ((> d 1) 0)
                   ((< d -1) 3.14159)
                   (else (acos d)))))))
 
 (define (boat-speed VW dW eta P)
    (let ((W (deg2rad dW)))
-     (let each-vb ((A W) (VA VW) (VB 0))
-       (let ((nVB (compute-VB A VA eta P)))
-       (if (<= (abs (- nVB VB)) 1e-8)
-           (print "A: " (rad2deg A) " VA: " VA " VB: "  VB)
-           (let* ((nVB (/ (+ nVB VB) 2))
-                  (nVA (compute-VA VW nVB W))
+     (let each-vb ((A W) (aws VW) (stw 0))
+       (let ((nVB (compute-stw A aws eta P)))
+       (if (<= (abs (- nVB stw)) 1e-8)
+           (print "A: " (rad2deg A) " aws: " aws " stw: "  stw)
+           (let* ((nVB (/ (+ nVB stw) 2))
+                  (nVA (compute-aws VW nVB W))
                   (nA (compute-A nVA nVB VW W)))
                (each-vb nA nVA nVB)))))))
 */
@@ -352,11 +352,11 @@ If the overall result is
 /* start out with the boat stopped, and over time, iterate accelerating boat
    until it reaches steady state.  The speed of the boat is known already
    from apparent wind, this function finds it for true wind */
-void BoatPlan::BoatSteadyState(double W, double VW, double &B, double &VB, double &A, double &VA,
+void BoatPlan::BoatSteadyState(double W, double VW, double &ctw, double &stw, double &A, double &aws,
                                 Boat &boat)
 {
     /* starting out not moving */
-    VB = 0, A = W, VA = VW;
+    stw = 0, A = W, aws = VW;
     double lp = .1;
 
     const int count = 128;
@@ -364,44 +364,44 @@ void BoatPlan::BoatSteadyState(double W, double VW, double &B, double &VB, doubl
     int bcount = 0;
 
     for(;;) {
-        double v = VelocityBoat(A, VA);
+        double v = VelocityBoat(A, aws);
 
         if(v == 0) { // we cannot sail this way
-            B = 0;
-            VB = 0;
+            ctw = 0;
+            stw = 0;
             return;
         }
-        double a = v - VB;
+        double a = v - stw;
 
-        double drag = boat.FrictionDrag(VB) + boat.WakeDrag(VB);
+        double drag = boat.FrictionDrag(stw) + boat.WakeDrag(stw);
 
         if(std::isnan(drag)) {
-            VB = 0;
+            stw = 0;
             return;
         }
         a -= drag;
 
         if(bcount == count) {
-            VB = bucket / count;
+            stw = bucket / count;
             a = 0;
         }
 
         if(fabs(a) < 1e-2 || lp < 1e-2) {
-            if(VB < 0) // not allowing backwards sailing
-                VB = 0;
-            B = AngleofAttackBoat(A, VA);
+            if(stw < 0) // not allowing backwards sailing
+                stw = 0;
+            ctw = AngleofAttackBoat(A, aws);
             return; /* reached steady state */
         }
 
         if(a < 0) {
-            bucket += VB;
+            bucket += stw;
             bcount++;
 //            lp *= .97;
         }
 
-        VB = (1-lp)*VB + lp*(VB+a); /* lowpass to get a smooth update */
-        VA = VelocityApparentWind(VB, W, VW);
-        A =  DirectionApparentWind(VA, VB, W, VW);
+        stw = (1-lp)*stw + lp*(stw+a); /* lowpass to get a smooth update */
+        aws = VelocityApparentWind(stw, W, VW);
+        A =  DirectionApparentWind(aws, stw, W, VW);
     }
 }
 
@@ -513,9 +513,9 @@ double Boat::HullSpeed()
 }
 
 /* assume frictional drag is related to speed squared */
-double Boat::FrictionDrag(double VB)
+double Boat::FrictionDrag(double stw)
 {
-    return 10*frictional_drag*VB*VB;
+    return 10*frictional_drag*stw*stw;
 }
 
 /* wave drag in terms of froude number
@@ -542,33 +542,33 @@ double Boat::FrictionDrag(double VB)
 
     This works for the full range from displacement to planing mode.
  */
-double Boat::WakeDrag(double VB)
+double Boat::WakeDrag(double stw)
 {
 #if 0 // this may be theoretically correct in flat water, but is complex and not practical
-    if(VB == 0) return 0;
+    if(stw == 0) return 0;
 
     const double G = 9.8;
     double L = ft2m(lwl_ft);
-    double F = knots2m_s(VB) / sqrt(G * L);
+    double F = knots2m_s(stw) / sqrt(G * L);
 
     double F2 = square(F), invF2 = 1/F2;
     double D = square(sin(M_PI - invF2) / (M_PI - invF2) / (1 + M_PI * F2));
 
-    return wake_drag * wake_drag * D * VB * VB; /* D is max of .25 (at F=.56) so normalize to 1 */
+    return wake_drag * wake_drag * D * stw * stw; /* D is max of .25 (at F=.56) so normalize to 1 */
 
 #else
     // classic hull speed exponential without planing possible
 //    double hull_speed = 1.34*sqrt(lwl_ft);
-//    double our_wave_drag = 2 * wake_drag * (pow(8, VB / sqrt(lwl_ft)) - 1);
+//    double our_wave_drag = 2 * wake_drag * (pow(8, stw / sqrt(lwl_ft)) - 1);
 
-    double coeff = VB / 1.34 / sqrt(lwl_ft);
+    double coeff = stw / 1.34 / sqrt(lwl_ft);
     if(coeff < 1)
         return 0;
 
     double drag = (pow(32, coeff - 1) - 1) * wake_drag * 10;
 
-    if(drag > VB)
-        drag = VB;
+    if(drag > stw)
+        drag = stw;
 
     return drag;
 #endif
@@ -598,20 +598,20 @@ void Boat::RecomputeDrag()
           
 
            2          2
-     VA sin (A/2) = VB eta
+     aws sin (A/2) = stw eta
 
-eta = VA*sin^2 (A/2)/VB^2
+eta = aws*sin^2 (A/2)/stw^2
 
 
         2        1 - cos(A)
      sin (A/2) = ----------
                      2
 
-eta = VA/VB^2*(1-cos(A))/2
+eta = aws/stw^2*(1-cos(A))/2
 
                  __
-           A    /VA
-VB =  sin (-)  /---
+           A    /aws
+stw =  sin (-)  /---
            2 \/ eta
 
 */

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -864,19 +864,19 @@ void WeatherRouting::UpdateRoutePositionDialog()
     dlg.m_stTacks->SetLabel(wxString::Format(_T("%d"), data.tacks));
     
     // BOAT SPEED
-    if (std::abs(data.VB - data.VBG) > 0.1) {
-        dlg.m_stBoatSpeed->SetLabel(wxString::Format(_T("%.1f knts (SOW), %.1f knts (SOG)"), data.VB, data.VBG));
+    if (std::abs(data.stw - data.sog) > 0.1) {
+        dlg.m_stBoatSpeed->SetLabel(wxString::Format(_T("%.1f knts (SOW), %.1f knts (SOG)"), data.stw, data.sog));
     }
     else {
-        dlg.m_stBoatSpeed->SetLabel(wxString::Format(_T("%.1f knts"), data.VB));
+        dlg.m_stBoatSpeed->SetLabel(wxString::Format(_T("%.1f knts"), data.stw));
     }
 
     // BEARING
-    if (std::abs(data.B - data.BG) >= 5) {
-        dlg.m_stBoatCourse->SetLabel(wxString::Format(_T("%.0f \u00B0T (COW), %.0f \u00B0T (COG)"), positive_degrees(data.B), positive_degrees(data.BG)));
+    if (std::abs(data.ctw - data.cog) >= 5) {
+        dlg.m_stBoatCourse->SetLabel(wxString::Format(_T("%.0f \u00B0T (COW), %.0f \u00B0T (COG)"), positive_degrees(data.ctw), positive_degrees(data.cog)));
     }
     else {
-        dlg.m_stBoatCourse->SetLabel(wxString::Format(_T("%.0f \u00B0T"), positive_degrees(data.B)));
+        dlg.m_stBoatCourse->SetLabel(wxString::Format(_T("%.0f \u00B0T"), positive_degrees(data.ctw)));
     }
     
     // WIND SPEED
@@ -886,7 +886,7 @@ void WeatherRouting::UpdateRoutePositionDialog()
     // WIND: TRUE WIND ANGLE
     // For wind direction, specify if it is
     // coming from starboard or port side.
-    double windDirection = heading_resolve(data.B - data.W);
+    double windDirection = heading_resolve(data.ctw - data.W);
     wxString windDirectionLabel;
     if (windDirection <= 0)
         windDirectionLabel = wxString::Format(_T("%.0f\u00B0 starboard"), fabs(windDirection));
@@ -895,11 +895,11 @@ void WeatherRouting::UpdateRoutePositionDialog()
     dlg.m_stTWA->SetLabel(windDirectionLabel);
     
     // WIND: APPARENT WIND SPEED
-    float apparentWindSpeed = Polar::VelocityApparentWind(data.VB, windDirection, data.VW);
+    float apparentWindSpeed = Polar::VelocityApparentWind(data.stw, windDirection, data.VW);
     dlg.m_stAWS->SetLabel(wxString::Format(_T("%.0f knts"), apparentWindSpeed));
     
     // WIND: APPARENT WIND SPEED
-    float apparentWindDirection = Polar::DirectionApparentWind(apparentWindSpeed, data.VB,
+    float apparentWindDirection = Polar::DirectionApparentWind(apparentWindSpeed, data.stw,
                                                                windDirection, data.VW);
     wxString apparentWindDirectionLabel;
     if (apparentWindDirection <= 0)


### PR DESCRIPTION
There are use cases when the weather routing is unable to compute a routing, even though for the same route and same GRIB files another software would complete. I am planning to fix some of these issues. However, before I do that, I propose to ease the code maintenance and understanding by making the following changes:
1. Add code comments to document the code.
2. Rename variables to use standard sailing conventions.

``` 
 - delta    → timeInterval   : Time from previous position (seconds)
 - VBG      → sog            : Speed Over Ground (knots)
 - BG       → cog            : Course Over Ground (degrees)
 - VB       → stw            : Speed Through Water (knots)
 - B        → ctw            : Course Through Water (degrees)
 - VW       → waterWindSpeed : Wind speed relative to water (knots)
 - W        → waterWindDir   : Wind direction relative to water (degrees)
 - VWG      → tws            : True Wind Speed (knots)
 - WG       → twd            : True Wind Direction (degrees)
 - VC       → currentSpeed   : Current speed (knots)
 - C        → currentDir     : Current direction (degrees)
 - WVHT     → swellHeight    : Significant wave height (meters)
 - VW_GUST  → gustSpeed      : Gust wind speed (knots)
 - VA       → aws            : Apparent wind speed (knots)
 - A        → awa            : Apparent wind angle (degrees)
```