### PR TITLE
Speed interpolation for low wind conditions

### DIFF
--- a/include/Boat.h
+++ b/include/Boat.h
@@ -138,6 +138,30 @@ public:
    */
   void GenerateCrossOverChart(void* arg = 0,
                               void (*status)(void*, int, int) = 0);
+  /**
+   * Attempts to find the best polar for light wind conditions.
+   *
+   * This function selects the most appropriate polar when the wind speed is
+   * below the minimum defined in any polar. It considers both the compatibility
+   * with the desired heading and how close the minimum wind speed is to our
+   * actual wind.
+   *
+   * @param curpolar Index of the current polar being used, or -1 if no polar is
+   * selected yet
+   * @param VW True wind speed in knots (below minimum in polars)
+   * @param H Heading relative to true wind direction in degrees
+   * @param Swell Swell height in meters
+   * @param optimize_tacking Whether to optimize the tacking angle for upwind
+   * sailing
+   * @param status Pointer to a PolarSpeedStatus variable to receive detailed
+   * status
+   *
+   * @return The index of the best polar to use, or -1 if no valid polar was
+   * found
+   */
+  int FindBestPolarForLightWind(int curpolar, double VW, double H, double Swell,
+                                bool optimize_tacking,
+                                PolarSpeedStatus* status = nullptr);
 
 private:
   Point Interp(const Point& p0, const Point& p1, int q, bool q0, bool q1);

--- a/include/Polar.h
+++ b/include/Polar.h
@@ -231,6 +231,12 @@ public:
    * index
    * @param[out] VW2i Reference to variable that will receive the upper bracket
    * index
+   *
+   * @note: if VW is less than the first wind speed in the table, VW1 is set to
+   * 0 and VW2i is set to 1.
+   * @note If VW is greater than the last wind speed in the table, VW1i is set
+   * to the index of the last wind speed and VW2i is set to the index of the
+   * last wind speed minus 1.
    */
   void ClosestVWi(double VW, int& VW1i, int& VW2i);
 
@@ -402,6 +408,7 @@ public:
 private:
   friend class EditPolarDialog;
   friend class BoatDialog;
+  friend class Boat;
 
   /**
    * Calculate and store the optimal VMG angles for a given wind speed entry in
@@ -499,7 +506,22 @@ private:
   bool VMGAngle(SailingWindSpeed& ws1, SailingWindSpeed& ws2, float VW,
                 float& W);
 
+  /**
+   * Stores boat performance data at different wind speeds.
+   * - The vector contains multiple SailingWindSpeed entries, each representing
+   *   boat performance at a specific true wind speed (tws).
+   * - Entries are ordered by increasing wind speed (from lowest to highest).
+   */
   std::vector<SailingWindSpeed> wind_speeds;
+  /**
+   * Stores the wind angles (in degrees) for which boat performance data
+   * is available in the polar diagram.
+   *
+   * Structure:
+   * - Contains wind angles in ascending order
+   * - Each entry corresponds to a column in the polar table
+   * - Ranges from the minimum pointing angle (close-hauled) to running downwind
+   */
   std::vector<double> degree_steps;
   unsigned int degree_step_index[DEGREES];
 };


### PR DESCRIPTION
# Changes in this PR

1. The simulation does not stop just because the next points in the propagation have little or no wind.
2. Implement linear interpolation for light wind conditions (e.g., if boat speed is 2 knots at TWS=4, then at TWS=3, approximate STW=1.5 knots). This means the boat will move very slowly or not at all for as long as the wind is light.
3. If the forecast predicts stronger winds at a later time, the simulation will find a path for the boat to sail towards the destination point.
4. The simulation will eventually stop if the low-wind conditions persist until the end of the forecast in the GRIB file and the destination has not been reached.

This PR is on top of #186 .

# Use Cases

Without wind interpolation, the algorithm fails to complete in the following scenarios:

1. Light wind around the starting point. The simulation steps through all angles at the start time but cannot find any wind values which are above the first wind index across all polars. For example, the first wind speed in the polar is 4 knots, but all GRIB values near the starting point are < 4 knots.
    - **Old behavior**: the simulation stops with "Polar: failed" error.
    - **New behavior**: the boat will stop moving (or very slow) for as long as the wind forecast is light. If the wind increases later (based on forecast), then the simulation can continue moving towards the destination point.
6. A similar light-wind issue can occur near the destination point, as there is no getting around the destination point.
7. Light-wind region on the way to the destination point.
   - **Old behavior**: the simulation stops propagating for every point that has light wind. If the light-wind region is large enough, the simulation might stop. A variant of this use case is when the simulation is forced to converge towards land.

# Notes

1. AFAIK, other weather routing software operate as described above.
2. When the simulation stops propagating, it's not obvious why all these paths are eliminated. Depending on where the light-wind zone is, it feels like the search angle is closing.

# Example

Below is an example where the starting point has light wind conditions. Before this PR, the simulation does not complete with "Polar: Failed" error (in fact, it fails immediately because the light wind issues are at the starting point).

As an aside, this simulation highlights separate problems:
1. gshhsCrossesLand not using high quality GSHHG files: #179
2. Computation can be quite slow (pre-existing issue). I am comparing to other programs that complete the simulation much faster. I'm guessing there is room for optimizations.

<img width="901" alt="image" src="https://github.com/user-attachments/assets/aaf1791b-1189-4064-b8f4-85fc8dc7f746" />

