### PR TITLE
Initial support for dynamic delta time between isochrons

### DIFF
--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -1502,6 +1502,19 @@ protected:
   virtual bool TestAbort() = 0;
 
   /**
+   * Determines the time step for the next isochrone generation based on current
+   * routing conditions.
+   *
+   * This function dynamically adjusts the time step to provide more detailed
+   * isochrones in critical areas:
+   * 1. Near the starting point
+   * 2. Approaching the destination
+   *
+   * @return The calculated time step in seconds to use for the next isochrone.
+   */
+  double DetermineDeltaTime();
+
+  /**
    * List of isochrones in chronological order.
    *
    * This is the core data structure that maintains all generated isochrones


### PR DESCRIPTION
# Changes in this PR

Introduce dynamic time steps, allowing the algorithm to use smaller time increments in critical navigation areas while using larger steps in open water.

# Implementation Details

1. Added a DetermineDeltaTime() method to dynamically calculate appropriate time steps based on current routing conditions.
2. Smaller time steps when leaving the starting point.
3. Smaller time steps when approaching the destination.
4. Fall back to normal time steps in open water areas.
5. Ensure a minimum time step (60 seconds) to maintain performance.

Follow-up PRs could focus on additional improvements:
1. Smaller steps when there are lots of obstructions (e.g. land)
2. Backtrack with smaller delta time if the propagation failed.
3. Implement adaptive behavior based on local weather conditions (reduce time steps in areas with rapidly changing winds)
4. Add current-based adaptation (smaller steps in areas with complex current patterns)

This should be merged after #189 has been merged.

Example:

<img width="680" alt="image" src="https://github.com/user-attachments/assets/56e023a1-4500-4ad2-ac7a-6c0c829ba113" />

