### PR TITLE
Display precision

### DIFF
--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -82,7 +82,7 @@ void PlotDialog::OnMouseEventsPlot(wxMouseEvent& event) {
   for (int i = 0; i < 3; i++) {
     double value = (1.0 - (double)p.y / h) * (m_maxvalue[i] - m_minvalue[i]) +
                    m_minvalue[i];
-    stMousePosition[i]->SetLabel(wxString::Format(_T(" %.3f"), value));
+    stMousePosition[i]->SetLabel(wxString::Format(_T(" %.1f"), value));
   }
 }
 

--- a/src/ReportDialog.cpp
+++ b/src/ReportDialog.cpp
@@ -102,13 +102,13 @@ void ReportDialog::SetRouteMapOverlays(
     double avgspeed = (*it)->RouteInfo(RouteMapOverlay::AVGSPEED);
     double avgspeedground = (*it)->RouteInfo(RouteMapOverlay::AVGSPEEDGROUND);
     page += _("Average Speed Over Water (SOW)") + wxString(_T(": ")) +
-            wxString::Format(_T(" %.2f"), avgspeed) + _T(" ") + _("knots") +
+            wxString::Format(_T(" %.1f"), avgspeed) + _T(" ") + _("knots") +
             _T("<dt>");
     page += _("Average Speed Over Ground (SOG)") + wxString(_T(": ")) +
-            wxString::Format(_T(" %.2f"), avgspeedground) + _T(" ") +
+            wxString::Format(_T(" %.1f"), avgspeedground) + _T(" ") +
             _("knots") + _T("<dt>");
     page += _("Average Wind") + wxString(_T(": ")) +
-            wxString::Format(_T(" %.2f"),
+            wxString::Format(_T(" %.1f"),
                              (*it)->RouteInfo(RouteMapOverlay::AVGWIND)) +
             _T(" ") + _("knots") + _T("<dt>");
 
@@ -117,18 +117,18 @@ void ReportDialog::SetRouteMapOverlays(
     // wind as it gives an indication on how strong will be the sailing
     // conditions, and if the crew has sufficient experience to handle it.
     page += _("Maximum Wind") + wxString(_T(": ")) +
-            wxString::Format(_T(" %.2f"),
+            wxString::Format(_T(" %.1f"),
                              (*it)->RouteInfo(RouteMapOverlay::MAXWIND)) +
             _T(" ") + _("knots") + _T("<dt>");
     ;
 
     page += _("Average Swell") + wxString(_T(": ")) +
-            wxString::Format(_T(" %.2f"),
+            wxString::Format(_T(" %.1f"),
                              (*it)->RouteInfo(RouteMapOverlay::AVGSWELL)) +
             _T(" ") + _("meters") + _T("<dt>");
     page +=
         _("Upwind") + wxString(_T(": ")) +
-        wxString::Format(_T(" %.2f%%"),
+        wxString::Format(_T(" %.1f%%"),
                          (*it)->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND)) +
         _T("<dt>");
     double port_starboard = (*it)->RouteInfo(RouteMapOverlay::PORT_STARBOARD);
@@ -159,7 +159,7 @@ void ReportDialog::SetRouteMapOverlays(
     double wspddiff = avgspeedground / avgspeed;
     if (fabs(1 - wspddiff) > .03) {
       page += wxString::Format(
-                  _T("%.2f%% "),
+                  _T("%.1f%% "),
                   ((wspddiff > 1 ? wspddiff : 1 / wspddiff) - 1) * 100.0) +
               _("speed change due to ");
       if (wspddiff > 1)
@@ -262,7 +262,7 @@ void ReportDialog::GenerateRoutesReport() {
 
     page += _("<dt>Fastest configuration ") + FormatTime(fastest->StartTime());
     page += wxString(_T(" ")) + _("avg speed") +
-            wxString::Format(_T(": %.2f "),
+            wxString::Format(_T(": %.1f "),
                              fastest->RouteInfo(RouteMapOverlay::AVGSPEED)) +
             _("knots");
 

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -211,12 +211,12 @@ WeatherRouting::WeatherRouting(wxWindow* parent, weather_routing_pi& plugin)
           "changed the names, your modifications will be overwritten, so be\n"
           "sure to backup your changes. If you have added new polars or boats\n"
           "with exclusive names, they will be kept untouched.\n\n");
-    message +=
-    _("Import example configurations will overwrite your route\n"
-    "configurations with a sample set showing you how WeatherRouting\n"
-    "works. Backup your existing configurations if you need.\n\n"
-    "Pressing \"OK\" will apply the selected changes, pressing \"Cancel\"\n"
-    "will do nothing and you will be asked again on the next launch.");
+    message += _(
+        "Import example configurations will overwrite your route\n"
+        "configurations with a sample set showing you how WeatherRouting\n"
+        "works. Backup your existing configurations if you need.\n\n"
+        "Pressing \"OK\" will apply the selected changes, pressing \"Cancel\"\n"
+        "will do nothing and you will be asked again on the next launch.");
 
     wxString confDlgChoices[3] = {_("Import new boats and polars"),
                                   _("Import example configurations")};
@@ -2198,42 +2198,42 @@ void WeatherRoute::Update(WeatherRouting* wr, bool stateonly) {
                                configuration.EndLat, configuration.EndLon));
 
     AvgSpeed = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGSPEED));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGSPEED));
 
     MaxSpeed = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXSPEED));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXSPEED));
 
     AvgSpeedGround = wxString::Format(
-        _T("%.2f"),
+        _T("%.1f"),
         routemapoverlay->RouteInfo(RouteMapOverlay::AVGSPEEDGROUND));
 
     MaxSpeedGround = wxString::Format(
-        _T("%.2f"),
+        _T("%.1f"),
         routemapoverlay->RouteInfo(RouteMapOverlay::MAXSPEEDGROUND));
 
     AvgWind = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGWIND));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGWIND));
 
     MaxWind = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXWIND));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXWIND));
 
     MaxWindGust = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXWINDGUST));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXWINDGUST));
 
     AvgCurrent = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGCURRENT));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGCURRENT));
 
     MaxCurrent = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXCURRENT));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXCURRENT));
 
     AvgSwell = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGSWELL));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::AVGSWELL));
 
     MaxSwell = wxString::Format(
-        _T("%.2f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXSWELL));
+        _T("%.1f"), routemapoverlay->RouteInfo(RouteMapOverlay::MAXSWELL));
 
     UpwindPercentage = wxString::Format(
-        _T("%.2f%%"),
+        _T("%.1f%%"),
         routemapoverlay->RouteInfo(RouteMapOverlay::PERCENTAGE_UPWIND));
 
     double ps = routemapoverlay->RouteInfo(RouteMapOverlay::PORT_STARBOARD);
@@ -2294,7 +2294,6 @@ void WeatherRoute::Update(WeatherRouting* wr, bool stateonly) {
           State += _T(": ");
           State += _("Failed");
         }
-
       }
     } else {
       for (std::list<RouteMapOverlay*>::iterator it =
@@ -2762,7 +2761,8 @@ void WeatherRouting::ExportRoute(RouteMapOverlay& routemapoverlay) {
 
 void WeatherRouting::Start(RouteMapOverlay* routemapoverlay) {
   if (!routemapoverlay ||
-      (routemapoverlay->Finished() && routemapoverlay->GetWeatherForecastStatus() == WEATHER_FORECAST_SUCCESS))
+      (routemapoverlay->Finished() &&
+       routemapoverlay->GetWeatherForecastStatus() == WEATHER_FORECAST_SUCCESS))
     return;
 
   RouteMapConfiguration configuration = routemapoverlay->GetConfiguration();


### PR DESCRIPTION
Fix #168

Use single-digit precision in the routing report for the following properties:
1. Average speed over water.
2. Average speed over ground.
3. Average wind.
4. Maximum wind
5. Average swell.
6. Max swell
7. Max speed
8. Max wind gust
9. Avg current
10. Max current

<img width="736" alt="image" src="https://github.com/user-attachments/assets/d7206c45-5ec8-4616-bcec-a70e84a72672" />


Plots values:

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/8a82ddc0-f83f-4459-8399-1c41fe5a6851" />

Route configuration:

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/316587a7-fc6a-452c-99bb-4137536a2094" />

