### PR TITLE
Add "Start from boat" radio button

### DIFF
--- a/include/ConfigurationDialog.h
+++ b/include/ConfigurationDialog.h
@@ -42,6 +42,23 @@ public:
   ~ConfigurationDialog();
 
   void EditBoat();
+  /**
+   * Updates the configuration dialog with settings from given route
+   * configurations
+   *
+   * @param configurations List of route map configurations to display/edit in
+   * dialog
+   *
+   * This method:
+   * - Updates all configuration controls to reflect the given route settings
+   * - Handles multiple selected configurations by showing common values
+   * - Called when route selection changes in weather routes list
+   * - Updates start/end positions, boat settings, weather parameters etc.
+   *
+   * Note: If multiple configurations are passed in, only settings that are the
+   * same across all configurations will be displayed. Others will show default
+   * values.
+   */
   void SetConfigurations(std::list<RouteMapConfiguration> configuration);
   void Update();
 
@@ -88,6 +105,8 @@ protected:
     wxDynamicCast(event.GetEventObject(), wxSpinCtrlDouble)->Enable();
     event.Skip();
   }
+  void OnStartFromBoat(wxCommandEvent& event);
+  void OnStartFromPosition(wxCommandEvent& event);
   void OnAvoidCyclones(wxCommandEvent& event);
   void OnAddDegreeStep(wxCommandEvent& event);
   void OnRemoveDegreeStep(wxCommandEvent& event);
@@ -97,8 +116,6 @@ protected:
 
 private:
   void UpdateCycloneControls();
-
-  enum ConfigurationItem { START, END, START_TIME, TIME_STEP };
 
   void SetStartDateTime(wxDateTime datetime);
 

--- a/include/PolygonRegion.h
+++ b/include/PolygonRegion.h
@@ -82,8 +82,9 @@ public:
   /**
    * Checks if a point is inside the polygon region.
    *
-   * Determines if a point with coordinates (x, y) is contained within the polygon region
-   * using a ray casting algorithm. Points on the boundary are considered inside.
+   * Determines if a point with coordinates (x, y) is contained within the
+   * polygon region using a ray casting algorithm. Points on the boundary are
+   * considered inside.
    *
    * @param x The x-coordinate of the point to check
    * @param y The y-coordinate of the point to check

--- a/include/RouteMapOverlay.h
+++ b/include/RouteMapOverlay.h
@@ -1,9 +1,4 @@
 /***************************************************************************
- *
- * Project:  OpenCPN Weather Routing plugin
- * Author:   Sean D'Epagnier
- *
- ***************************************************************************
  *   Copyright (C) 2015 by Sean D'Epagnier                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -20,8 +15,7 @@
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
- ***************************************************************************
- */
+ ***************************************************************************/
 
 #include "RouteMap.h"
 #include "LineBufferOverlay.h"
@@ -33,146 +27,438 @@ class piDC;
 class RouteMapOverlay;
 class SettingsDialog;
 
+/**
+ * Thread class for route map overlay calculations.
+ * Handles the background processing for weather route generation.
+ */
 class RouteMapOverlayThread : public wxThread {
 public:
+  /**
+   * Constructor for the thread.
+   * @param routemapoverlay Reference to the parent RouteMapOverlay object.
+   */
   RouteMapOverlayThread(RouteMapOverlay& routemapoverlay);
+
+  /**
+   * Thread entry point that performs the route calculation.
+   * @return Thread exit code.
+   */
   void* Entry();
 
 private:
+  /** Reference to the parent RouteMapOverlay object. */
   RouteMapOverlay& m_RouteMapOverlay;
 };
 
+/**
+ * Main class for the weather routing overlay.
+ * Extends RouteMap to provide visualization and user interaction capabilities.
+ */
 class RouteMapOverlay : public RouteMap {
   friend class RouteMapOverlayThread;
 
 public:
+  /**
+   * Information types available for route analysis.
+   */
   enum RouteInfoType {
-    DISTANCE,
-    AVGSPEED,
-    MAXSPEED,
-    AVGSPEEDGROUND,
-    MAXSPEEDGROUND,
-    AVGWIND,
-    MAXWIND,
-    MAXWINDGUST,
-    AVGCURRENT,
-    MAXCURRENT,
-    AVGSWELL,
-    MAXSWELL,
-    PERCENTAGE_UPWIND,
-    PORT_STARBOARD,
-    TACKS,
-    COMFORT
+    DISTANCE,           //!< Total distance of the route
+    AVGSPEED,           //!< Average speed through water
+    MAXSPEED,           //!< Maximum speed through water
+    AVGSPEEDGROUND,     //!< Average speed over ground
+    MAXSPEEDGROUND,     //!< Maximum speed over ground
+    AVGWIND,            //!< Average wind speed
+    MAXWIND,            //!< Maximum wind speed
+    MAXWINDGUST,        //!< Maximum wind gust
+    AVGCURRENT,         //!< Average current speed
+    MAXCURRENT,         //!< Maximum current speed
+    AVGSWELL,           //!< Average swell height
+    MAXSWELL,           //!< Maximum swell height
+    PERCENTAGE_UPWIND,  //!< Percentage of time sailing upwind
+    PORT_STARBOARD,     //!< Percentage of time on port tack
+    TACKS,              //!< Number of tacks performed
+    COMFORT             //!< Sailing comfort level
   };
 
+  /**
+   * Default constructor.
+   * Initializes a new RouteMapOverlay with default values.
+   */
   RouteMapOverlay();
+
+  /**
+   * Destructor.
+   * Cleans up resources and stops any running threads.
+   */
   ~RouteMapOverlay();
 
+  /**
+   * Updates the cursor position on the route map.
+   * @param lat Latitude of the cursor position.
+   * @param lon Longitude of the cursor position.
+   * @return True if the cursor position changed, false otherwise.
+   */
   bool SetCursorLatLon(double lat, double lon);
+
+  /**
+   * Renders the route map overlay on the viewport.
+   * @param time Current time for boat position rendering.
+   * @param settingsdialog Reference to settings dialog for display options.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   * @param justendroute If true, only renders the end route.
+   * @param positionOnRoute Optional position to mark on the route.
+   */
   void Render(wxDateTime time, SettingsDialog& settingsdialog, piDC& dc,
               PlugIn_ViewPort& vp, bool justendroute,
               RoutePoint* positionOnRoute = nullptr);
 
+  /**
+   * Gets a color representing a sailing comfort level.
+   * @param level Comfort level (1-3).
+   * @return Color corresponding to the comfort level.
+   */
   static wxColour sailingConditionColor(int level);
+
+  /**
+   * Gets a text description of a sailing comfort level.
+   * @param level Comfort level (1-3).
+   * @return Text description of the comfort level.
+   */
   static wxString sailingConditionText(int level);
 
+  /**
+   * Renders wind barbs across the map.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void RenderWindBarbs(piDC& dc, PlugIn_ViewPort& vp);
 
+  /**
+   * Renders current arrows across the map.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void RenderCurrent(piDC& dc, PlugIn_ViewPort& vp);
 
+  /**
+   * Gets the latitude and longitude bounds of the route map.
+   * @param latmin Output parameter for minimum latitude.
+   * @param latmax Output parameter for maximum latitude.
+   * @param lonmin Output parameter for minimum longitude.
+   * @param lonmax Output parameter for maximum longitude.
+   */
   void GetLLBounds(double& latmin, double& latmax, double& lonmin,
                    double& lonmax);
+
+  /**
+   * Requests grib data for a specific time.
+   * @param time Time for which to request grib data.
+   */
   void RequestGrib(wxDateTime time);
 
+  /**
+   * Gets plot data for either the cursor route or destination route.
+   * @param cursor_route If true, gets data for cursor route, otherwise for
+   * destination route.
+   * @return Reference to a list of plot data points.
+   */
   std::list<PlotData>& GetPlotData(bool cursor_route = false);
+
+  /**
+   * Gets specific route information based on type.
+   * @param type Type of information to retrieve.
+   * @param cursor_route If true, gets info for cursor route, otherwise for
+   * destination route.
+   * @return The requested route information value.
+   */
   double RouteInfo(enum RouteInfoType type, bool cursor_route = false);
+
+  /**
+   * Counts the number of cyclone track crossings.
+   * @param months Optional array to count crossings by month.
+   * @return Number of cyclone crossings, or -1 if cyclone data is unavailable.
+   */
   int Cyclones(int* months);
+
+  /**
+   * Gets the destination position.
+   * @return Pointer to the destination position.
+   */
   Position* GetDestination() { return destination_position; }
 
+  /**
+   * Checks if the route has been updated.
+   * @return True if the route has been updated since last check.
+   */
   bool Updated();
+
+  /**
+   * Updates the cursor position based on cached lat/lon.
+   * Updates the internal cursor position state.
+   */
   void UpdateCursorPosition();
+
+  /**
+   * Updates the destination position.
+   * Calculates the closest reachable position to the destination.
+   */
   void UpdateDestination();
 
+  /**
+   * Gets the end time of the route.
+   * @return The calculated end time.
+   */
   wxDateTime EndTime() { return m_EndTime; }
 
+  /**
+   * Clears all route data.
+   * Resets the route map to its initial state.
+   */
   virtual void Clear();
+
+  /**
+   * Locks the route map for thread-safe access.
+   */
   virtual void Lock() { routemutex.Lock(); }
+
+  /**
+   * Unlocks the route map after thread-safe access.
+   */
   virtual void Unlock() { routemutex.Unlock(); }
+
+  /**
+   * Checks if the calculation thread is still running.
+   * @return True if the thread is running.
+   */
   bool Running() { return m_Thread && m_Thread->IsAlive(); }
 
+  /**
+   * Starts the route calculation thread.
+   * @param error Output parameter for error messages.
+   * @return True if the thread started successfully.
+   */
   bool Start(wxString& error);
+
+  /**
+   * Deletes the calculation thread.
+   * Waits for thread completion before deleting.
+   */
   void DeleteThread();  // like Stop(), but waits until the thread is deleted
 
+  /**
+   * Gets the last cursor position.
+   * @return Pointer to the last cursor position.
+   */
   Position* GetLastCursorPosition() { return last_cursor_position; }
+
+  /**
+   * Gets the time at the last cursor position.
+   * @return Time at the last cursor position.
+   */
   wxDateTime GetLastCursorTime() { return m_cursor_time; }
 
-  // CUSTOMIZATION
+  /**
+   * Gets the closest route position to a given cursor latitude and longitude.
+   * @param cursorLat Cursor latitude.
+   * @param cursorLon Cursor longitude.
+   * @param posData Output parameter for position data.
+   * @return Pointer to the closest route position.
+   */
   Position* getClosestRoutePositionFromCursor(double cursorLat,
                                               double cursorLon,
                                               PlotData& posData);
 
+  /** Flag indicating if the overlay needs to be updated. */
   bool m_UpdateOverlay;
+
+  /** Flag indicating if the end route should be visible. */
   bool m_bEndRouteVisible;
+
+  /**
+   * Performs route analysis on a predefined route.
+   * @param proute Pointer to the route to analyze.
+   */
   void RouteAnalysis(PlugIn_Route* proute);
 
 private:
+  /**
+   * Renders an alternate route.
+   * @param r Pointer to the route to render.
+   * @param each_parent If true, renders each parent.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void RenderAlternateRoute(IsoRoute* r, bool each_parent, piDC& dc,
                             PlugIn_ViewPort& vp);
 
+  /**
+   * Renders a single isochron route.
+   * @param r Pointer to the route to render.
+   * @param grib_color Color for grib-based segments.
+   * @param climatology_color Color for climatology-based segments.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void RenderIsoRoute(IsoRoute* r, wxColour& grib_color,
                       wxColour& climatology_color, piDC& dc,
                       PlugIn_ViewPort& vp);
+
+  /**
+   * Renders markers at points where the polar changes.
+   * @param cursor_route If true, renders for cursor route, otherwise for
+   * destination route.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void RenderPolarChangeMarks(bool cursor_route, piDC& dc, PlugIn_ViewPort& vp);
+
+  /**
+   * Renders the boat position on the course at a given time.
+   * @param cursor_route If true, renders for cursor route, otherwise for
+   * destination route.
+   * @param time Time at which to render the boat.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void RenderBoatOnCourse(bool cursor_route, wxDateTime time, piDC& dc,
                           PlugIn_ViewPort& vp);
 
-  // Customization ComfortDisplay
+  /**
+   * Renders the calculated course.
+   * @param cursor_route If true, renders cursor route, otherwise destination
+   * route.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   * @param comfortRoute If true, colors the route by sailing comfort.
+   */
   void RenderCourse(bool cursor_route, piDC& dc, PlugIn_ViewPort& vp,
                     bool comfortRoute = false);
 
-  // Customization WindBarbsOnRoute
+  /**
+   * Renders wind barbs along the route.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   * @param lineWidth Width of the wind barb lines.
+   * @param apparentWind If true, shows apparent wind, otherwise true wind.
+   */
   void RenderWindBarbsOnRoute(piDC& dc, PlugIn_ViewPort& vp, int lineWidth,
                               bool apparentWind);
 
+  /**
+   * Calculates the sailing comfort level for a given plot position.
+   * @param plot The plot data to analyze.
+   * @return Comfort level (1-3).
+   */
   int sailingConditionLevel(const PlotData& plot) const;
 
+  /**
+   * Checks if the route calculation should be aborted.
+   * @return True if the calculation should be aborted.
+   */
   virtual bool TestAbort() { return Finished(); }
 
+  /** Pointer to the calculation thread. */
   RouteMapOverlayThread* m_Thread;
+
+  /** Mutex for thread-safe access to route data. */
   wxMutex routemutex;
 
+  /**
+   * Sets the point color based on position data.
+   * @param dc Device context for drawing.
+   * @param p Position to get the color for.
+   */
   void SetPointColor(piDC& dc, Position* p);
+
+  /**
+   * Draws a line between two route points.
+   * @param p1 First point.
+   * @param p2 Second point.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void DrawLine(RoutePoint* p1, RoutePoint* p2, piDC& dc, PlugIn_ViewPort& vp);
+
+  /**
+   * Draws a line between two route points with color gradation.
+   * @param p1 First point.
+   * @param color1 Color for the first point.
+   * @param p2 Second point.
+   * @param color2 Color for the second point.
+   * @param dc Device context for drawing.
+   * @param vp ViewPort for coordinate transformations.
+   */
   void DrawLine(RoutePoint* p1, wxColour& color1, RoutePoint* p2,
                 wxColour& color2, piDC& dc, PlugIn_ViewPort& vp);
 
-  double last_cursor_lat, last_cursor_lon;
-  Position *last_cursor_position, *destination_position,
-      *last_destination_position;
+  /** Last cursor latitude. */
+  double last_cursor_lat;
+
+  /** Last cursor longitude. */
+  double last_cursor_lon;
+
+  /** Pointer to the last cursor position. */
+  Position* last_cursor_position;
+
+  /** Pointer to the destination position. */
+  Position* destination_position;
+
+  /** Pointer to the last destination position. */
+  Position* last_destination_position;
+
+  /** Time at the cursor position. */
   wxDateTime m_cursor_time;
+
+  /** End time of the route. */
   wxDateTime m_EndTime;
+
+  /** Flag indicating if the route has been updated. */
   bool m_bUpdated;
 
-  int m_overlaylist, m_overlaylist_projection;
+  /** Display list for OpenGL rendering. */
+  int m_overlaylist;
 
-  bool clear_destination_plotdata;  // should be volatile
+  /** Projection type for the current display list. */
+  int m_overlaylist_projection;
+
+  /** Flag indicating if destination plot data should be cleared. Should be
+   * volatile. */
+  bool clear_destination_plotdata;
+
+  /** Plot data for the destination route. */
   std::list<PlotData> last_destination_plotdata;
 
+  /** Plot data for the cursor route. */
   std::list<PlotData> last_cursor_plotdata;
 
+  /** Line buffer for wind barb caching. */
   LineBuffer wind_barb_cache;
+
+  /** Scale factor for wind barb cache. */
   double wind_barb_cache_scale;
+
+  /** Original size of the origin list when the wind barb cache was created. */
   size_t wind_barb_cache_origin_size;
+
+  /** Projection type for the wind barb cache. */
   int wind_barb_cache_projection;
 
-  // Customization WindBarbsOnRoute
+  /** Line buffer for wind barbs along the route. */
   LineBuffer wind_barb_route_cache;
 
-  // Customization Sailing Comfort
+  /** Current sailing comfort level. */
   int m_sailingComfort;
 
+  /** Line buffer for current arrow caching. */
   LineBuffer current_cache;
+
+  /** Scale factor for current cache. */
   double current_cache_scale;
+
+  /** Original size of the origin list when the current cache was created. */
   size_t current_cache_origin_size;
+
+  /** Projection type for the current cache. */
   int current_cache_projection;
 };

--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -52,13 +52,44 @@ class WeatherRoute {
 public:
   WeatherRoute();
   ~WeatherRoute();
+  /**
+   * Updates the weather route object with current configuration and calculation
+   * status.
+   *
+   * This method updates both the route configuration data and status
+   * information. It's used whenever route information needs to be refreshed in
+   * the UI.
+   *
+   * @param wr Pointer to the WeatherRouting main object to access settings
+   * @param stateonly If true, only update the State field, not configuration
+   * data
+   */
   void Update(WeatherRouting* wr, bool stateonly = false);
 
   bool Filtered;
-  wxString BoatFilename, Start, StartTime, End, EndTime, Time, Distance,
-      AvgSpeed, MaxSpeed, AvgSpeedGround, MaxSpeedGround, AvgWind, MaxWind,
-      MaxWindGust, AvgCurrent, MaxCurrent, AvgSwell, MaxSwell, UpwindPercentage,
-      PortStarboard, Tacks, State, Comfort;
+  wxString BoatFilename;
+  wxString Start;
+  wxString StartTime;
+  wxString End;
+  wxString EndTime;
+  wxString Time;
+  wxString Distance;
+  wxString AvgSpeed;
+  wxString MaxSpeed;
+  wxString AvgSpeedGround;
+  wxString MaxSpeedGround;
+  wxString AvgWind;
+  wxString MaxWind;
+  wxString MaxWindGust;
+  wxString AvgCurrent;
+  wxString MaxCurrent;
+  wxString AvgSwell;
+  wxString MaxSwell;
+  wxString UpwindPercentage;
+  wxString PortStarboard;
+  wxString Tacks;
+  wxString State;
+  wxString Comfort;
   RouteMapOverlay* routemapoverlay;
 };
 
@@ -127,6 +158,13 @@ public:
 
   void UpdateCurrentConfigurations();
   void UpdateStates();
+  /**
+   * Get list of currently selected route maps in the weather routes list
+   *
+   * @param messagedialog If true, show warning dialog when no routes are
+   * selected
+   * @return List of RouteMapOverlay pointers for selected routes
+   */
   std::list<RouteMapOverlay*> CurrentRouteMaps(bool messagedialog = false);
   RouteMapOverlay* FirstCurrentRouteMap();
   RouteMapOverlay* m_RouteMapOverlayNeedingGrib;
@@ -219,7 +257,17 @@ private:
   RouteMap* SelectedRouteMap();
   void Export(RouteMapOverlay& routemapoverlay);
   void ExportRoute(RouteMapOverlay& routemapoverlay);
-  /* Start the computation of the specified route. */
+  /**
+   * Initiates route calculation for a specific route map overlay.
+   *
+   * This method handles the pre-computation setup for a route map overlay:
+   * - If starting from boat position, it updates the start coordinates
+   * - It attempts to start the computation thread
+   * - It handles any errors that occur during startup
+   * - It adds successful starts to the running routes list
+   *
+   * @param routemapoverlay Pointer to the route map overlay to compute
+   */
   void Start(RouteMapOverlay* routemapoverlay);
   void StartAll();
   /* Stop the computation of the specified route. */

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -85,7 +85,7 @@ protected:
   wxMenuItem* m_mBatch1;
   wxMenu* m_menu1;
 
-  // Virtual event handlers, overide them in your derived class
+  // Virtual event handlers, override them in your derived class
   virtual void OnClose(wxCloseEvent& event) { event.Skip(); }
   virtual void OnSize(wxSizeEvent& event) { event.Skip(); }
   virtual void OnOpen(wxCommandEvent& event) { event.Skip(); }
@@ -101,6 +101,17 @@ protected:
   virtual void OnGoTo(wxCommandEvent& event) { event.Skip(); }
   virtual void OnDelete(wxCommandEvent& event) { event.Skip(); }
   virtual void OnDeleteAll(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * Handles the "Compute" button click event.
+   *
+   * This method starts the computation process for all currently selected route
+   * configurations. It retrieves the list of selected route maps, initiates the
+   * computation for each one, and updates the UI to reflect the ongoing
+   * computation state.
+   *
+   * @param event The button click event (unused but required by event handler
+   * signature)
+   */
   virtual void OnCompute(wxCommandEvent& event) { event.Skip(); }
   virtual void OnComputeAll(wxCommandEvent& event) { event.Skip(); }
   virtual void OnStop(wxCommandEvent& event) { event.Skip(); }
@@ -160,6 +171,17 @@ protected:
   virtual void OnWeatherRouteSort(wxListEvent& event) { event.Skip(); }
   virtual void OnWeatherRouteSelected(wxListEvent& event) { event.Skip(); }
   virtual void OnWeatherRouteKeyDown(wxListEvent& event) { event.Skip(); }
+  /**
+   * Handles the "Compute" button click event.
+   *
+   * This method starts the computation process for all currently selected route
+   * configurations. It retrieves the list of selected route maps, initiates the
+   * computation for each one, and updates the UI to reflect the ongoing
+   * computation state.
+   *
+   * @param event The button click event (unused but required by event handler
+   * signature)
+   */
   virtual void OnCompute(wxCommandEvent& event) { event.Skip(); }
   virtual void OnExport(wxCommandEvent& event) { event.Skip(); }
   virtual void OnExportRoute(wxCommandEvent& event) { event.Skip(); }
@@ -167,6 +189,13 @@ protected:
 public:
   wxSplitterWindow* m_splitter1;
   wxListCtrl* m_lPositions;
+  /**
+   * List control that displays configured weather routes.
+   *
+   * This list control contains route configurations and their computed results.
+   * Each row represents a weather route with columns showing properties like
+   * Name, Start position, End position.
+   */
   wxListCtrl* m_lWeatherRoutes;
   wxButton* m_bCompute;
   wxButton* m_bExport;
@@ -240,6 +269,10 @@ private:
 protected:
   wxNotebook* m_notebook7;
   wxPanel* m_pBasic;
+  /** Radio buttons for start selection */
+  wxRadioButton* m_rbStartFromBoat;
+  wxRadioButton* m_rbStartPositionSelection;
+  /** The starting point of the route. */
   wxComboBox* m_cStart;
   wxStaticText* m_staticText28;
   wxButton* m_bGribTime;
@@ -261,6 +294,7 @@ protected:
   wxStaticText* m_staticText27;
   wxSpinCtrl* m_sMaxSwellMeters;
   wxStaticText* m_staticText129;
+  /** The end point of the route. */
   wxComboBox* m_cEnd;
   wxSpinCtrl* m_sTimeStepHours;
   wxStaticText* m_staticText110;
@@ -308,6 +342,8 @@ protected:
   wxButton* m_bResetAdvanced;
 
   // Virtual event handlers, overide them in your derived class
+  virtual void OnStartFromBoat(wxCommandEvent& event) { event.Skip(); }
+  virtual void OnStartFromPosition(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdate(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdateDate(wxDateEvent& event) { event.Skip(); }
   virtual void OnGribTime(wxCommandEvent& event) { event.Skip(); }

--- a/include/weather_routing_pi.h
+++ b/include/weather_routing_pi.h
@@ -101,6 +101,13 @@
 
 class WeatherRouting;
 
+/**
+ * OpenCPN Weather Routing plugin main class.
+ *
+ * Implements the OpenCPN Weather Routing plugin that provides
+ * weather routing capabilities to OpenCPN. It handles initialization,
+ * UI management, and interactions with the OpenCPN application.
+ */
 class weather_routing_pi : public wxEvtHandler, public opencpn_plugin_118 {
 public:
   weather_routing_pi(void* ppimgr);
@@ -132,9 +139,20 @@ public:
 
   int GetToolbarToolCount();
 
+  /**
+   * Receives cursor lat/lon position updates.
+   *
+   * @param lat Latitude of the cursor.
+   * @param lon Longitude of the cursor.
+   */
   void SetCursorLatLon(double lat, double lon);
 
   void SetPluginMessage(wxString& message_id, wxString& message_body);
+  /**
+   * Handle position fix information (boat position).
+   *
+   * @param pfix Position fix information.
+   */
   void SetPositionFixEx(PlugIn_Position_Fix_Ex& pfix);
   void ShowPreferencesDialog(wxWindow* parent);
 
@@ -145,8 +163,10 @@ public:
   static wxString StandardPath();
   void ShowMenuItems(bool show);
 
-  double m_boat_lat, m_boat_lon;
-  double m_cursor_lat, m_cursor_lon;
+  double m_boat_lat;    //!< Latitude of the boat position, in degrees.
+  double m_boat_lon;    //!< Longitude of the boat position, in degrees.
+  double m_cursor_lat;  //!< Latitude of the cursor position, in degrees.
+  double m_cursor_lon;  //!< Longitude of the cursor position, in degrees.
 
 private:
   void OnCursorLatLonTimer(wxTimerEvent&);

--- a/src/EditPolarDialog.cpp
+++ b/src/EditPolarDialog.cpp
@@ -50,7 +50,7 @@ EditPolarDialog::EditPolarDialog(wxWindow* parent)
 #endif
       m_BoatDialog(static_cast<BoatDialog*>(parent)) {
   //	m_gPolar->Connect( wxEVT_GRID_CELL_CHANGED, wxGridEventHandler(
-  //EditPolarDialogBase::OnPolarGridChanged ), NULL, this );
+  // EditPolarDialogBase::OnPolarGridChanged ), NULL, this );
 
   m_lMeasurements->InsertColumn(spTRUE_WIND_SPEED, _("True Wind Speed"));
   m_lMeasurements->InsertColumn(spTRUE_WIND_DIRECTION,

--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -101,9 +101,9 @@ double PlotDialog::GetValue(PlotData& data, int var) {
     case WIND_VELOCITY:
       return data.VW;
     case WIND_DIRECTION:
-      return heading_resolve(data.ctw - data.W);
+      return heading_resolve(data.ctw - data.twa);
     case WIND_COURSE:
-      return positive_degrees(data.W);
+      return positive_degrees(data.twa);
 
     case WIND_VELOCITY_GROUND:
       return data.tws;

--- a/src/ReportDialog.cpp
+++ b/src/ReportDialog.cpp
@@ -82,7 +82,11 @@ void ReportDialog::SetRouteMapOverlays(
 
     page += _("Boat Filename") + _T(" ") +
             wxFileName(c.boatFileName).GetName() + _T("<dt>");
-    page += _("Route from ") + c.Start + _(" to ") + c.End + _T("<dt>");
+    if (c.StartType == RouteMapConfiguration::START_FROM_BOAT) {
+      page += _("Route from ") + _("Boat") + _(" to ") + c.End + _T("<dt>");
+    } else {
+      page += _("Route from ") + c.Start + _(" to ") + c.End + _T("<dt>");
+    }
     page += _("Leaving ") + FormatTime((*it)->StartTime()) + _T("<dt>");
     if (d) {
       page += _("Arriving ") + FormatTime((*it)->EndTime()) + _T("<dt>");
@@ -423,7 +427,7 @@ void ReportDialog::GenerateRoutesReport() {
 
 void ReportDialog::OnInformation(wxCommandEvent& event) {
   wxString mes =
-  _("Weather Routing Reports gives an overview of a given route based on \
+      _("Weather Routing Reports gives an overview of a given route based on \
   multiple configurations.\n\n\
   For example using the configuration batch dialog, it is possible to \
   easily generate multiple otherwise identical configurations which \
@@ -436,6 +440,6 @@ void ReportDialog::OnInformation(wxCommandEvent& event) {
   cyclone risk and additional weather conditions may be described.");
 
   wxMessageDialog mdlg(this, mes, _("Weather Routing Report"),
-      wxOK | wxICON_INFORMATION);
+                       wxOK | wxICON_INFORMATION);
   mdlg.ShowModal();
 }

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -670,7 +670,7 @@ int RouteMapOverlay::sailingConditionLevel(const PlotData& plot) const {
   // conditions as if you sail downwind (impact of waves, heel, and more).
   // Use a normal distribution to set the maximum difficulty at 35° upwind,
   // and reduce when we go downwind.
-  double AW = heading_resolve(plot.ctw - plot.W);
+  double AW = heading_resolve(plot.ctw - plot.twa);
   double teta = 30;
   double mu = 35;
   double amp = 20;
@@ -870,7 +870,7 @@ void RouteMapOverlay::RenderWindBarbsOnRoute(piDC& dc, PlugIn_ViewPort& vp,
     //   cog sog : boat speed over ground
     //   ctw  stw  : boat speed over water
     float windSpeed = it->VW;
-    float windDirection = it->W;  // heading_resolve(it->ctw - it->W);
+    float windDirection = it->twa;  // heading_resolve(it->ctw - it->W);
 
     // By default, display true wind
     float finalWindSpeed = windSpeed;
@@ -1473,10 +1473,10 @@ double RouteMapOverlay::RouteInfo(enum RouteInfoType type, bool cursor_route) {
         if (total < it->WVHT) total = it->WVHT;
         break;
       case PERCENTAGE_UPWIND:
-        if (fabs(heading_resolve(it->ctw - it->W)) < 90) total++;
+        if (fabs(heading_resolve(it->ctw - it->twa)) < 90) total++;
         break;
       case PORT_STARBOARD:
-        if (heading_resolve(it->ctw - it->W) > 0) total++;
+        if (heading_resolve(it->ctw - it->twa) > 0) total++;
         break;
       // CUSTOMIZATION
       // Comfort on route

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -224,20 +224,23 @@ void SettingsDialog::OnHelp(wxCommandEvent& event) {
   wxSize sz = ::wxGetDisplaySize();
   SetSize(0, 0, sz.x, sz.y - 40);
 #endif
-  wxString mes = _("\
+  wxString mes =
+      _("\
 Cursor Route -- optimal route closest to the cursor\n\
 Destination Route -- optimal route to the desired destination\n\
 Route Thickness -- thickness to draw Cursor and Destination Routes\n\
 Iso Chron Thickness -- thickness for isochrons on map\n\
 Alternate Routes Thickness -- thickness for alternate routes\n");
 
-mes += _("Note: All thicknesses can be set to 0 to disable their display\n\
+  mes +=
+      _("Note: All thicknesses can be set to 0 to disable their display\n\
 Alternates for all Isochrons -- display all alternate routes not only \
 the ones which reach the last isochron\n\
 Squares At Sail Changes -- render squares along Routes whenever \
 a sail change is made\n");
 
-mes += _("Filter Routes by Climatology -- This currently does nothing, \
+  mes +=
+      _("Filter Routes by Climatology -- This currently does nothing, \
 but I intended to make weather route maps which derive data \
 from grib and climatology clearly render which data was used where \n\\n\
 Number of Concurrent Threads -- if there are multiple configurations, \
@@ -245,6 +248,6 @@ they can be computed in separate threads which allows a speedup \
 if there are multiple processors\n");
 
   wxMessageDialog mdlg(this, mes, _("Weather Routing"),
-      wxOK | wxICON_INFORMATION);
+                       wxOK | wxICON_INFORMATION);
   mdlg.ShowModal();
 }

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1048,6 +1048,24 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   fgSizer60->SetFlexibleDirection(wxBOTH);
   fgSizer60->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
+  // Add radio button group for start selection
+  wxBoxSizer* startSelectionSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  m_rbStartFromBoat =
+      new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Start from boat"),
+                        wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  startSelectionSizer->Add(m_rbStartFromBoat, 0,
+                           wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+  m_rbStartPositionSelection =
+      new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Start position"),
+                        wxDefaultPosition, wxDefaultSize);
+  m_rbStartPositionSelection->SetValue(true);  // Default to position selection
+  startSelectionSizer->Add(m_rbStartPositionSelection, 0,
+                           wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+  fgSizer60->Add(startSelectionSizer, 0, wxEXPAND, 5);
+
   m_cStart =
       new wxComboBox(sbStart->GetStaticBox(), wxID_ANY, wxEmptyString,
                      wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY);
@@ -1735,6 +1753,14 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   this->Centre(wxBOTH);
 
   // Connect Events
+  m_rbStartFromBoat->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnStartFromBoat), NULL,
+      this);
+  m_rbStartPositionSelection->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnStartFromPosition), NULL,
+      this);
   m_cStart->Connect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                     wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
                     NULL, this);
@@ -2182,6 +2208,14 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
 
 ConfigurationDialogBase::~ConfigurationDialogBase() {
   // Disconnect Events
+  m_rbStartFromBoat->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnStartFromBoat), NULL,
+      this);
+  m_rbStartPositionSelection->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnStartFromPosition), NULL,
+      this);
   m_cStart->Disconnect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                        wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
                        NULL, this);

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -131,6 +131,8 @@ int weather_routing_pi::Init() {
 
   m_pWeather_Routing = NULL;
 
+  RouteMapConfiguration::s_plugin_instance = this;
+
 #ifdef PLUGIN_USE_SVG
   m_leftclick_tool_id = InsertPlugInToolSVG(
       _T( "WeatherRouting" ), _svg_weather_routing,
@@ -273,9 +275,9 @@ void weather_routing_pi::SetPluginMessage(wxString& message_id,
         wxMessageDialog mdlg(
             m_parent_window,
             _("Grib plugin version not supported.") + _T("\n\n") +
-                wxString::Format("%s %d.%d to %d.%d", ver,
-                                 GRIB_MIN_MAJOR, GRIB_MIN_MINOR,
-                                 GRIB_MAX_MAJOR, GRIB_MAX_MINOR),
+                wxString::Format("%s %d.%d to %d.%d", ver, GRIB_MIN_MAJOR,
+                                 GRIB_MIN_MINOR, GRIB_MAX_MAJOR,
+                                 GRIB_MAX_MINOR),
             _("Weather Routing"), wxOK | wxICON_WARNING);
         mdlg.ShowModal();
       }
@@ -327,8 +329,8 @@ void weather_routing_pi::SetPluginMessage(wxString& message_id,
               "data.") +
                 _T("\n\n") +
                 wxString::Format("%s %d.%d to %d.%d", ver,
-                                CLIMATOLOGY_MIN_MAJOR, CLIMATOLOGY_MIN_MINOR,
-                                CLIMATOLOGY_MAX_MAJOR, CLIMATOLOGY_MAX_MINOR),
+                                 CLIMATOLOGY_MIN_MAJOR, CLIMATOLOGY_MIN_MINOR,
+                                 CLIMATOLOGY_MAX_MAJOR, CLIMATOLOGY_MAX_MINOR),
             _("Weather Routing"), wxOK | wxICON_WARNING);
         mdlg.ShowModal();
         return;


### PR DESCRIPTION
# Changes in this PR

In the Weather Routing Configuration dialog, add radio buttons to select either:
1. "Start from boat" or
2. "Start position" - as selected in drop-down list.

Default selection is "Start position" to maintain backward compatibility

Related issues: #188

<img width="893" alt="image" src="https://github.com/user-attachments/assets/85f254f1-264d-40f2-a7c7-fb117c23749d" />

## Detailed Changes

1. Create `StartDataType` enum in `RouteConfiguration` to specify whether starting point is from current boat location (e.g. based on position fix), or from specified position (mark).
2. Add radio buttons in the UI to specify "Start From Boat" or start from selected position (mark).
3. In UI initialization, set values of radio buttons based on the RouteConfiguration.
4. When generating route summary, indicate whether the route starts from boat or from selected position.
5. Save/Load `StartType` parameter in configuration file.
6. Add methods such that when Route calculation starts, we can get the current boat location if the requested route is from the boat.
7. When user clicks the "Compute" button and the route has already been calculated, and the route starts from the boat, determine if the boat has moved significantly since the last computation. If yes, recompute the route.
8. Refactor some variables for better maintainability.
9. Add code comments.
10. Fix typos.

# Benefits

1. Users can now explicitly choose to start weather routing from their current boat position, without having to create a position and click "update boat position.
2. This provides a more intuitive interface for a common use case.
11. For multi-day routes, users can get updated GRIB data every few hours and recalculate the route to the same destination without having to create a new route.

One big benefit is that the user can repeatedly click "Compute" to update the route. If the boat position has changed and is perhaps no longer on the same track, then the computation restarts from the current boat position, without having to manually update the boat position.

<img width="621" alt="image" src="https://github.com/user-attachments/assets/32743f43-50c5-4a40-a826-bd37757ad294" />

# Tests

- [x] When "Start position" is selected:
   - [x] The dropdown is enabled.
   - [x] When the user clicks "Compute", the calculation start from the selected start point to the end point.
- [x] When "Start from boat" is selected:
   - [x] The start position dropdown is disabled
   - [x] The "Start" attribute shows "from boat" instead of another position.
   - [x] When the user clicks "Compute", the plugin obtains the current position of the boat and starts the computation.
   - [x] If a computation has completed and the boat position has changed, the user can click "Compute" again. In that case, the calculation is done from the updated boat position.


# Follow-up Enhancements.

1. Add checkbox to start from current time, meaning get the current time when the calculation starts. This would be especially useful when you are sailing towards a destination, you have selected "start from boat" and you just want to be able to click "Compute" to recalculate without having to change the configuration. You are en route, so you shouldn't have to manually click the "Current Time" button.
2. Use dead reckoning to estimate the boat position about 1 minute from now. Since the calculation takes some time, the boat will have moved by the time the calculation completes. This is unlikely to have a significant impact, it's just an idea.

<img width="608" alt="image" src="https://github.com/user-attachments/assets/3a70c517-c591-437d-9e43-ee0f9ee488c6" />
