### PR TITLE
Add Automatic Current Time Option for Route Calculations

### DIFF
--- a/include/ConfigurationDialog.h
+++ b/include/ConfigurationDialog.h
@@ -86,6 +86,7 @@ protected:
     OnValueChange(event);
     Update();
   }
+  void OnUseCurrentTime(wxCommandEvent& event);
   void OnGribTime(wxCommandEvent& event);
   void OnCurrentTime(wxCommandEvent& event);
   void OnUpdateSpin(wxSpinEvent& event) {

--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -917,6 +917,8 @@ struct RouteMapConfiguration {
 
   /** The time when the boat leaves the starting position. */
   wxDateTime StartTime;
+  /** Flag to use the current time as the start time. */
+  bool UseCurrentTime;
   /** Default time in seconds between propagations. */
   double DeltaTime;
   /** Time in seconds between propagations. */

--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -1,9 +1,4 @@
-/***************************************************************************
- *
- * Project:  OpenCPN Weather Routing plugin
- * Author:   Sean D'Epagnier
- *
- ***************************************************************************
+/**************************************************************************
  *   Copyright (C) 2016 by Sean D'Epagnier                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -19,9 +14,8 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.             *
- ***************************************************************************
- */
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************/
 
 #ifndef _WEATHER_ROUTING_H_
 #define _WEATHER_ROUTING_H_
@@ -48,10 +42,29 @@
 class weather_routing_pi;
 class WeatherRouting;
 
+/**
+ * Class representing a weather routing configuration and its associated route.
+ *
+ * This class serves as a UI-focused wrapper that combines both configuration
+ * settings and calculation results. While RouteMapConfiguration stores the raw
+ * routing parameters and RouteMapOverlay handles the actual route computation
+ * and display, WeatherRoute maintains the human-readable representation of
+ * route data for display in the UI.
+ *
+ * The class stores formatted strings for distance, speed, weather conditions,
+ * and other metrics rather than raw numerical values. It works closely with the
+ * WeatherRouting dialog to present route information in a user-friendly format.
+ *
+ * @see RouteMapConfiguration For the underlying route parameters and settings
+ * @see RouteMapOverlay For the actual route calculation and display
+ * functionality
+ * @see WeatherRouting For the main routing interface that manages these routes
+ */
 class WeatherRoute {
 public:
   WeatherRoute();
   ~WeatherRoute();
+
   /**
    * Updates the weather route object with current configuration and calculation
    * status.
@@ -60,36 +73,92 @@ public:
    * information. It's used whenever route information needs to be refreshed in
    * the UI.
    *
-   * @param wr Pointer to the WeatherRouting main object to access settings
+   * @param wr Pointer to the WeatherRouting main object to access settings.
    * @param stateonly If true, only update the State field, not configuration
-   * data
+   * data.
    */
   void Update(WeatherRouting* wr, bool stateonly = false);
 
+  /** Flag indicating if this route is filtered out in the UI display. */
   bool Filtered;
+
+  /** Path to the boat characteristics file used for this route. */
   wxString BoatFilename;
+
+  /** Starting position name/coordinates. */
   wxString Start;
+
+  /** Specifies whether to set the StartTime to the current computer time at the
+   * start of the calculation. */
+  wxString UseCurrentTime;
+
+  /** Starting position type (boat or named). */
+  wxString StartType;
+
+  /** Departure time for the route. */
   wxString StartTime;
+
+  /** Destination position name/coordinates. */
   wxString End;
+
+  /** Estimated arrival time at destination. */
   wxString EndTime;
+
+  /** Total route duration. */
   wxString Time;
+
+  /** Total route distance in nautical miles. */
   wxString Distance;
+
+  /** Average boat speed through water in knots. */
   wxString AvgSpeed;
+
+  /** Maximum boat speed through water in knots. */
   wxString MaxSpeed;
+
+  /** Average boat speed over ground including currents in knots. */
   wxString AvgSpeedGround;
+
+  /** Maximum boat speed over ground in knots. */
   wxString MaxSpeedGround;
+
+  /** Average wind speed encountered in knots. */
   wxString AvgWind;
+
+  /** Maximum sustained wind speed encountered in knots. */
   wxString MaxWind;
+
+  /** Maximum wind gust encountered in knots. */
   wxString MaxWindGust;
+
+  /** Average current speed encountered in knots. */
   wxString AvgCurrent;
+
+  /** Maximum current speed encountered in knots. */
   wxString MaxCurrent;
+
+  /** Average swell height encountered in meters. */
   wxString AvgSwell;
+
+  /** Maximum swell height encountered in meters. */
   wxString MaxSwell;
+
+  /** Percentage of time spent sailing upwind. */
   wxString UpwindPercentage;
+
+  /** Distribution between port and starboard tacks. */
   wxString PortStarboard;
+
+  /** Number of tacks/gybes performed. */
   wxString Tacks;
+
+  /** Current computation state of the route. */
   wxString State;
+
+  /** Comfort/safety metrics for the route conditions. */
   wxString Comfort;
+
+  /** Pointer to the actual route calculation and display overlay. */
   RouteMapOverlay* routemapoverlay;
 };
 
@@ -101,34 +170,38 @@ private:
   WeatherRoutingPanel* m_panel;
 
 public:
-  enum { POSITION_NAME = 0, POSITION_LAT, POSITION_LON };
+  enum {
+    POSITION_NAME = 0,  //!< Position identifier/name
+    POSITION_LAT,       //!< Latitude coordinate
+    POSITION_LON        //!< Longitude coordinate
+  };
 
   enum {
-    VISIBLE = 0,
-    BOAT,
-    START,
-    STARTTIME,
-    END,
-    ENDTIME,
-    TIME,
-    DISTANCE,
-    AVGSPEED,
-    MAXSPEED,
-    AVGSPEEDGROUND,
-    MAXSPEEDGROUND,
-    AVGWIND,
-    MAXWIND,
-    MAXWINDGUST,
-    AVGCURRENT,
-    MAXCURRENT,
-    AVGSWELL,
-    MAXSWELL,
-    UPWIND_PERCENTAGE,
-    PORT_STARBOARD,
-    TACKS,
-    COMFORT,
-    STATE,
-    NUM_COLS
+    VISIBLE = 0,        //!< Route visibility toggle state
+    BOAT,               //!< Boat configuration file name
+    START,              //!< Starting position name/coordinates
+    STARTTIME,          //!< Route departure time
+    END,                //!< Destination position name/coordinates
+    ENDTIME,            //!< Estimated arrival time
+    TIME,               //!< Total route duration
+    DISTANCE,           //!< Total route distance in nautical miles
+    AVGSPEED,           //!< Average boat speed through water in knots
+    MAXSPEED,           //!< Maximum boat speed through water in knots
+    AVGSPEEDGROUND,     //!< Average boat speed over ground in knots
+    MAXSPEEDGROUND,     //!< Maximum boat speed over ground in knots
+    AVGWIND,            //!< Average wind speed encountered in knots
+    MAXWIND,            //!< Maximum sustained wind speed in knots
+    MAXWINDGUST,        //!< Maximum wind gust encountered in knots
+    AVGCURRENT,         //!< Average current speed encountered in knots
+    MAXCURRENT,         //!< Maximum current speed encountered in knots
+    AVGSWELL,           //!< Average swell height encountered in meters
+    MAXSWELL,           //!< Maximum swell height encountered in meters
+    UPWIND_PERCENTAGE,  //!< Percentage of time spent sailing upwind
+    PORT_STARBOARD,     //!< Distribution between port and starboard tacks
+    TACKS,              //!< Number of tacks/gybes performed
+    COMFORT,            //!< Comfort/safety metrics for conditions
+    STATE,              //!< Current computation state of route
+    NUM_COLS            //!< Total number of display columns
   };
   long columns[NUM_COLS];
   static const wxString column_names[NUM_COLS];

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -275,9 +275,33 @@ protected:
   /** The starting point of the route. */
   wxComboBox* m_cStart;
   wxStaticText* m_staticText28;
+  /**
+   * Button to set the start time to match the currently loaded GRIB file's
+   * time. Clicking this button will set the time controls to match the valid
+   * time of the currently loaded weather GRIB file. This is useful for ensuring
+   * the route calculation begins with valid weather data.
+   */
   wxButton* m_bGribTime;
+  /**
+   * Checkbox to automatically use current time when computing a route.
+   * When checked, the starting time will always be updated to the current
+   * system time at the moment computation begins. This option is particularly
+   * useful when repeatedly recalculating routes that start from the boat's
+   * current position during active navigation, as it ensures the calculation
+   * always uses the latest time without requiring manual time updates from the
+   * user.
+   */
+  wxCheckBox* m_cbUseCurrentTime;
   wxStaticText* m_staticText30;
   wxTimePickerCtrl* m_tpTime;
+  /**
+   * Button to set the start time to the current system time.
+   * Clicking this button will update the date and time controls to the current
+   * system time. This is useful for quickly setting up a route that starts
+   * at the present moment. This button is disabled when m_cbUseCurrentTime is
+   * checked, as the current time will be automatically used when computation
+   * begins.
+   */
   wxButton* m_bCurrentTime;
   wxTextCtrl* m_tBoat;
   wxButton* m_bBoatFilename;
@@ -346,6 +370,7 @@ protected:
   virtual void OnStartFromPosition(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdate(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdateDate(wxDateEvent& event) { event.Skip(); }
+  virtual void OnUseCurrentTime(wxCommandEvent& event) { event.Skip(); }
   virtual void OnGribTime(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdateTime(wxDateEvent& event) { event.Skip(); }
   virtual void OnCurrentTime(wxCommandEvent& event) { event.Skip(); }

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -81,7 +81,6 @@ void ConfigurationDialog::EditBoat() {
   m_WeatherRouting.m_BoatDialog.LoadPolar(m_tBoat->GetValue());
   m_WeatherRouting.m_BoatDialog.Show();
 }
-
 void ConfigurationDialog::OnGribTime(wxCommandEvent& event) {
   SetStartDateTime(m_GribTimelineTime);
   Update();
@@ -89,6 +88,14 @@ void ConfigurationDialog::OnGribTime(wxCommandEvent& event) {
 
 void ConfigurationDialog::OnCurrentTime(wxCommandEvent& event) {
   SetStartDateTime(wxDateTime::Now().ToUTC());
+  Update();
+}
+
+void ConfigurationDialog::OnUseCurrentTime(wxCommandEvent& event) {
+  m_dpStartDate->Enable(!m_cbUseCurrentTime->IsChecked());
+  m_tpTime->Enable(!m_cbUseCurrentTime->IsChecked());
+  m_bGribTime->Enable(!m_cbUseCurrentTime->IsChecked());
+  m_bCurrentTime->Enable(!m_cbUseCurrentTime->IsChecked());
   Update();
 }
 
@@ -205,8 +212,15 @@ void ConfigurationDialog::SetConfigurations(
                     wxDateTime, wxDateTime());
   SET_CONTROL_VALUE(STARTTIME, m_tpTime, SetValue, wxDateTime, wxDateTime());
 
-  m_bCurrentTime->Enable(m_tpTime->IsEnabled() && m_dpStartDate->IsEnabled());
-  m_bGribTime->Enable(m_tpTime->IsEnabled() && m_dpStartDate->IsEnabled());
+  SET_CHECKBOX(UseCurrentTime);
+
+  bool timeButtonsEnabled = m_tpTime->IsEnabled() &&
+                            m_dpStartDate->IsEnabled() &&
+                            !m_cbUseCurrentTime->IsChecked();
+  m_dpStartDate->Enable(timeButtonsEnabled);
+  m_tpTime->Enable(timeButtonsEnabled);
+  m_bCurrentTime->Enable(timeButtonsEnabled);
+  m_bGribTime->Enable(timeButtonsEnabled);
 
   SET_SPIN_VALUE(TimeStepHours, (int)((*it).DeltaTime / 3600));
   SET_SPIN_VALUE(TimeStepMinutes, ((int)(*it).DeltaTime / 60) % 60);
@@ -239,6 +253,11 @@ void ConfigurationDialog::SetConfigurations(
 
   m_cStart->Enable(!oRoute && !m_rbStartFromBoat->GetValue());
   m_cEnd->Enable(!oRoute);
+
+  m_bGribTime->Enable(!m_cbUseCurrentTime->IsChecked());
+  m_bCurrentTime->Enable(!m_cbUseCurrentTime->IsChecked());
+  m_dpStartDate->Enable(!m_cbUseCurrentTime->IsChecked());
+  m_tpTime->Enable(!m_cbUseCurrentTime->IsChecked());
 
   SET_SPIN(FromDegree);
   SET_SPIN(ToDegree);
@@ -402,6 +421,8 @@ void ConfigurationDialog::Update() {
     if (configuration.StartType == RouteMapConfiguration::START_FROM_POSITION)
       GET_CHOICE(Start);
     GET_CHOICE(End);
+
+    GET_CHECKBOX(UseCurrentTime);
 
     if (NO_EDITED_CONTROLS ||
         std::find(m_edited_controls.begin(), m_edited_controls.end(),

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -37,7 +37,7 @@
 #include "weather_routing_pi.h"
 #include "WeatherRouting.h"
 
-const wxString SettingsDialog::column_names[] = {"",
+const wxString SettingsDialog::column_names[] = {"",  // "Visible" column
                                                  "Boat",
                                                  "Start",
                                                  "Start Time",

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -538,6 +538,10 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
 
   m_bCompute = new wxButton(sbSizer29->GetStaticBox(), wxID_ANY, _("&Compute"),
                             wxDefaultPosition, wxDefaultSize, 0);
+  // Add after m_bCompute creation, around line 539:
+  m_bCompute->SetToolTip(
+      _("Calculate weather route based on selected start/end positions and "
+        "configuration"));
   fgSizer116->Add(m_bCompute, 0, wxALL, 5);
 
   m_bExport = new wxButton(sbSizer29->GetStaticBox(), wxID_ANY,
@@ -792,40 +796,58 @@ SettingsDialogBase::SettingsDialogBase(wxWindow* parent, wxWindowID id,
   m_cbDisplayCursorRoute =
       new wxCheckBox(m_scrolledWindow4, wxID_ANY, _("Display Cursor Route"),
                      wxDefaultPosition, wxDefaultSize, 0);
+  m_cbDisplayCursorRoute->SetToolTip(
+      _("Show the cursor route line when dragging on the chart"));
   m_cbDisplayCursorRoute->SetValue(true);
   fgSizer82->Add(m_cbDisplayCursorRoute, 0, wxALL, 5);
 
   m_cbAlternatesForAll = new wxCheckBox(m_scrolledWindow4, wxID_ANY,
                                         _("Alternates for all IsoChrons"),
                                         wxDefaultPosition, wxDefaultSize, 0);
+  m_cbAlternatesForAll->SetToolTip(
+      _("Generate alternate routes for all isochronal points rather than just "
+        "endpoints"));
+
   fgSizer82->Add(m_cbAlternatesForAll, 0, wxALL, 5);
 
   m_cbMarkAtPolarChange = new wxCheckBox(m_scrolledWindow4, wxID_ANY,
                                          _("Display mark when Polar changes"),
                                          wxDefaultPosition, wxDefaultSize, 0);
+  m_cbMarkAtPolarChange->SetToolTip(
+      _("Display marks on the route where polar changes occur due to wind "
+        "conditions"));
   m_cbMarkAtPolarChange->SetValue(true);
   fgSizer82->Add(m_cbMarkAtPolarChange, 0, wxALL, 5);
 
   m_cbDisplayCurrent =
       new wxCheckBox(m_scrolledWindow4, wxID_ANY, _("Display current"),
                      wxDefaultPosition, wxDefaultSize, 0);
+  m_cbDisplayCurrent->SetToolTip(_("Show current arrows along the route"));
   m_cbDisplayCurrent->SetValue(true);
   fgSizer82->Add(m_cbDisplayCurrent, 0, wxALL, 5);
 
   m_cbDisplayWindBarbs =
       new wxCheckBox(m_scrolledWindow4, wxID_ANY, _("Display Wind Barbs"),
                      wxDefaultPosition, wxDefaultSize, 0);
+  m_cbDisplayWindBarbs->SetToolTip(
+      _("Show wind barbs along the route indicating wind direction and speed"));
   fgSizer82->Add(m_cbDisplayWindBarbs, 0, wxALL, 5);
 
   m_cbDisplayApparentWindBarbs =
       new wxCheckBox(m_scrolledWindow4, wxID_ANY,
                      _("Apparent Wind for Barbs On Route (not True Wind)"),
                      wxDefaultPosition, wxDefaultSize, 0);
+  m_cbDisplayApparentWindBarbs->SetToolTip(
+      _("Display apparent wind barbs instead of true wind barbs along the "
+        "route"));
   fgSizer82->Add(m_cbDisplayApparentWindBarbs, 0, wxALL, 5);
 
   m_cbDisplayComfort = new wxCheckBox(m_scrolledWindow4, wxID_ANY,
                                       _("Display Sailing Comfort on Route"),
                                       wxDefaultPosition, wxDefaultSize, 0);
+  m_cbDisplayComfort->SetToolTip(
+      _("Show sailing comfort measurement along the route based on wind and "
+        "wave conditions"));
   fgSizer82->Add(m_cbDisplayComfort, 0, wxALL, 5);
 
   fgSizer18->Add(fgSizer82, 1, wxEXPAND, 5);
@@ -877,6 +899,8 @@ SettingsDialogBase::SettingsDialogBase(wxWindow* parent, wxWindowID id,
 
   m_cbUseLocalTime = new wxCheckBox(this, wxID_ANY, _("Use Local Time"),
                                     wxDefaultPosition, wxDefaultSize, 0);
+  m_cbUseLocalTime->SetToolTip(
+      _("Display times in local time zone instead of UTC"));
   fgSizer101->Add(m_cbUseLocalTime, 1, wxALL | wxEXPAND, 5);
 
   fgSizer100->Add(fgSizer101, 1, wxEXPAND | wxALL, 5);
@@ -1054,12 +1078,16 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_rbStartFromBoat =
       new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Start from boat"),
                         wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  m_rbStartFromBoat->SetToolTip(
+      _("Use current boat position as the starting point"));
   startSelectionSizer->Add(m_rbStartFromBoat, 0,
                            wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
   m_rbStartPositionSelection =
       new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Start position"),
                         wxDefaultPosition, wxDefaultSize);
+  m_rbStartPositionSelection->SetToolTip(
+      _("Select a predefined position as the starting point"));
   m_rbStartPositionSelection->SetValue(true);  // Default to position selection
   startSelectionSizer->Add(m_rbStartPositionSelection, 0,
                            wxALL | wxALIGN_CENTER_VERTICAL, 5);
@@ -1069,7 +1097,17 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_cStart =
       new wxComboBox(sbStart->GetStaticBox(), wxID_ANY, wxEmptyString,
                      wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY);
+  m_cStart->SetToolTip(
+      _("Choose the starting position from the list of available positions"));
   fgSizer60->Add(m_cStart, 1, wxALL | wxEXPAND, 5);
+
+  m_cbUseCurrentTime =
+      new wxCheckBox(sbStart->GetStaticBox(), wxID_ANY, _("Use current time"),
+                     wxDefaultPosition, wxDefaultSize, 0);
+  m_cbUseCurrentTime->SetToolTip(
+      _("When enabled, uses the actual time at the moment the routing "
+        "computation starts"));
+  fgSizer60->Add(m_cbUseCurrentTime, 0, wxALL, 5);
 
   wxFlexGridSizer* fgSizer111;
   fgSizer111 = new wxFlexGridSizer(0, 3, 0, 0);
@@ -1085,11 +1123,15 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_dpStartDate = new wxDatePickerCtrl(
       sbStart->GetStaticBox(), wxID_ANY, wxDefaultDateTime, wxDefaultPosition,
       wxDefaultSize, wxDP_ALLOWNONE | wxDP_DEFAULT);
+  m_dpStartDate->SetToolTip(_("Select the starting date for weather routing"));
   fgSizer111->Add(m_dpStartDate, 1, wxALIGN_CENTER_VERTICAL | wxALL | wxEXPAND,
                   5);
 
   m_bGribTime = new wxButton(sbStart->GetStaticBox(), wxID_ANY, _("Grib Time"),
                              wxDefaultPosition, wxDefaultSize, 0);
+  m_bGribTime->SetToolTip(
+      _("Set date/time to match currently selected time in the GRIB weather "
+        "forecast plugin"));
   fgSizer111->Add(m_bGribTime, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND | wxALL,
                   5);
 
@@ -1102,11 +1144,13 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_tpTime =
       new wxTimePickerCtrl(sbStart->GetStaticBox(), wxID_ANY, wxDefaultDateTime,
                            wxDefaultPosition, wxDefaultSize, wxDP_DEFAULT);
+  m_tpTime->SetToolTip(_("Select the starting time for weather routing"));
   fgSizer111->Add(m_tpTime, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND | wxALL, 5);
 
   m_bCurrentTime =
       new wxButton(sbStart->GetStaticBox(), wxID_ANY, _("Current Time"),
                    wxDefaultPosition, wxDefaultSize, 0);
+  m_bCurrentTime->SetToolTip(_("Set to current date and time"));
   fgSizer111->Add(m_bCurrentTime, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND | wxALL,
                   5);
 
@@ -1161,6 +1205,11 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sMaxDivertedCourse = new wxSpinCtrl(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
       wxSize(-1, -1), wxSP_ARROW_KEYS, 0, 180, 180);
+  m_sMaxDivertedCourse->SetToolTip(
+      _("Maximum course variation from great circle (shortest) route in "
+        "degrees.\nLarger values allow finding alternate routes but increase "
+        "computation time.\nNote: Alternate routes may be necessary to avoid "
+        "land or find better weather."));
   m_sMaxDivertedCourse->SetMaxSize(wxSize(140, -1));
 
   fgSizer110->Add(m_sMaxDivertedCourse, 1,
@@ -1181,6 +1230,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sMaxTrueWindKnots = new wxSpinCtrl(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
       wxSize(-1, -1), wxSP_ARROW_KEYS, 0, 200, 60);
+  m_sMaxTrueWindKnots->SetToolTip(
+      _("Maximum true wind speed to allow during routing.\nRoutes with wind "
+        "speeds above this value will be avoided."));
   m_sMaxTrueWindKnots->SetMaxSize(wxSize(140, -1));
 
   fgSizer110->Add(m_sMaxTrueWindKnots, 1,
@@ -1202,6 +1254,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sMaxApparentWindKnots = new wxSpinCtrl(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
       wxSize(-1, -1), wxSP_ARROW_KEYS, 0, 200, 60);
+  m_sMaxApparentWindKnots->SetToolTip(
+      _("Maximum apparent wind speed to allow during routing.\nRoutes with "
+        "apparent wind speeds above this value will be avoided."));
   m_sMaxApparentWindKnots->SetMaxSize(wxSize(140, -1));
 
   fgSizer110->Add(m_sMaxApparentWindKnots, 1,
@@ -1222,6 +1277,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sMaxSwellMeters = new wxSpinCtrl(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
       wxSize(-1, -1), wxSP_ARROW_KEYS, 0, 100, 20);
+  m_sMaxSwellMeters->SetToolTip(
+      _("Maximum swell height to allow during routing.\nRoutes with swell "
+        "heights above this value will be avoided."));
   m_sMaxSwellMeters->SetMaxSize(wxSize(140, -1));
 
   fgSizer110->Add(m_sMaxSwellMeters, 1,
@@ -1252,6 +1310,8 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_cEnd =
       new wxComboBox(sbEnd->GetStaticBox(), wxID_ANY, wxEmptyString,
                      wxDefaultPosition, wxDefaultSize, 0, NULL, wxCB_READONLY);
+  m_cEnd->SetToolTip(_(
+      "Choose the destination position from the list of available positions"));
   sbEnd->Add(m_cEnd, 0, wxALL | wxEXPAND, 5);
 
   fgSizer112->Add(sbEnd, 1, wxEXPAND | wxALL, 5);
@@ -1268,6 +1328,7 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sTimeStepHours = new wxSpinCtrl(
       sbTime_Step->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
       wxSize(-1, -1), wxALIGN_RIGHT | wxSP_ARROW_KEYS, 0, 1000, 1);
+  m_sTimeStepHours->SetToolTip(_("Hours between each calculation step"));
   m_sTimeStepHours->SetMaxSize(wxSize(140, -1));
 
   fgSizer921->Add(m_sTimeStepHours, 0, wxALL, 5);
@@ -1281,6 +1342,7 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sTimeStepMinutes = new wxSpinCtrl(
       sbTime_Step->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
       wxSize(-1, -1), wxALIGN_RIGHT | wxSP_ARROW_KEYS, 0, 60, 1);
+  m_sTimeStepMinutes->SetToolTip(_("Minutes between each calculation step"));
   m_sTimeStepMinutes->SetMaxSize(wxSize(140, -1));
 
   fgSizer921->Add(m_sTimeStepMinutes, 0, wxALL, 5);
@@ -1307,17 +1369,21 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_cbDetectLand =
       new wxCheckBox(sbOptions->GetStaticBox(), wxID_ANY, _("Detect Land"),
                      wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
+  m_cbDetectLand->SetToolTip(_("Detect land crossings and avoid them"));
   m_cbDetectLand->SetValue(true);
   fgSizer23->Add(m_cbDetectLand, 1, wxALL | wxEXPAND, 5);
 
   m_cbDetectBoundary =
       new wxCheckBox(sbOptions->GetStaticBox(), wxID_ANY, _("Detect Boundary"),
                      wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
+  m_cbDetectBoundary->SetToolTip(
+      _("Detect configured boundaries and avoid crossing them"));
   fgSizer23->Add(m_cbDetectBoundary, 1, wxALL | wxEXPAND, 5);
 
   m_cbCurrents =
       new wxCheckBox(sbOptions->GetStaticBox(), wxID_ANY, _("Currents"),
                      wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
+  m_cbCurrents->SetToolTip(_("Include currents in routing calculation"));
   m_cbCurrents->SetValue(true);
   fgSizer23->Add(m_cbCurrents, 1, wxALL | wxEXPAND, 5);
 
@@ -1346,6 +1412,7 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
 
   m_cbUseGrib = new wxCheckBox(sbData_Source->GetStaticBox(), wxID_ANY,
                                _("Grib"), wxDefaultPosition, wxDefaultSize, 0);
+  m_cbUseGrib->SetToolTip(_("Use GRIB weather data for routing"));
   m_cbUseGrib->SetValue(true);
   fgSizer59->Add(m_cbUseGrib, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
@@ -1770,6 +1837,10 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_dpStartDate->Connect(
       wxEVT_DATE_CHANGED,
       wxDateEventHandler(ConfigurationDialogBase::OnUpdateDate), NULL, this);
+  m_cbUseCurrentTime->Connect(
+      wxEVT_COMMAND_CHECKBOX_CLICKED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnUseCurrentTime), NULL,
+      this);
   m_bGribTime->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(ConfigurationDialogBase::OnGribTime), NULL, this);
@@ -2225,6 +2296,10 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
   m_dpStartDate->Disconnect(
       wxEVT_DATE_CHANGED,
       wxDateEventHandler(ConfigurationDialogBase::OnUpdateDate), NULL, this);
+  m_cbUseCurrentTime->Disconnect(
+      wxEVT_COMMAND_CHECKBOX_CLICKED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnUseCurrentTime), NULL,
+      this);
   m_bGribTime->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(ConfigurationDialogBase::OnGribTime), NULL, this);


### PR DESCRIPTION
This is a follow-up PR to #210 

# Overview

Add a new "Use Current Time for Calculation" checkbox to the route configuration dialog. When enabled, the system automatically uses the current time when the "Compute" button is pressed, eliminating the need to manually update the time before each recalculation during active navigation.

<img width="454" alt="image" src="https://github.com/user-attachments/assets/5ace3a29-7c29-4b40-b161-16de829c42e6" />


# Changes

1. Added a new checkbox in the Configuration Dialog to enable automatic current time usage.
2. Time-setting buttons (date/time widget; GRIB Time, Current Time buttons) are automatically disabled when this option is enabled.
3. Implemented the logic to update the calculation start time automatically when computation begins.
4. Save and Load the `UseCurrentTime` attribute to/from the configuration file.
5. Add tooltips.

# Benefits

This enhancement is particularly useful for sailors who are actively following a weather-routed course and want to periodically recalculate the optimal route based on their current boat position and the current time.

By eliminating the need to manually update the time before each recalculation, it streamlines the sailing workflow, allowing more frequent route optimizations with fewer manual operations.
