### PR TITLE
Add "Save As" functionality and Auto Save to Weather Routing

### DIFF
--- a/include/BoatDialog.h
+++ b/include/BoatDialog.h
@@ -55,11 +55,96 @@ private:
   void OnUpdatePlot();
   void OnUpdatePlot(wxCommandEvent& event) { OnUpdatePlot(); }
   void OnUpdatePlot(wxSpinEvent& event) { OnUpdatePlot(); }
+  /**
+   * Opens a boat configuration file.
+   *
+   * This method displays a file dialog allowing the user to select an XML boat
+   * configuration file. Upon selection, it stores the selected directory as the
+   * default path for future boat file operations, then attempts to open the
+   * boat file.
+   *
+   * A boat configuration file contains a collection of polar files, typically
+   * with different polars representing different sail configurations or
+   * conditions. The file defines how the boat performs at different wind angles
+   * and speeds across various sail settings.
+   *
+   * If the file is successfully loaded, the polar list is repopulated with all
+   * the polars from the boat configuration and the plots are refreshed. If
+   * loading fails, an error message is displayed.
+   *
+   * @param event The command event (unused)
+   * @see m_Boat.OpenXML() For the actual file parsing functionality
+   * @see RepopulatePolars() For updating the polar list display
+   * @see UpdateVMG() For recalculating velocity made good values
+   * @see RefreshPlots() For updating the polar plots
+   */
   void OnOpenBoat(wxCommandEvent& event);
+  /**
+   * Saves the current boat configuration to the specified file.
+   *
+   * This is the core implementation that handles saving the boat configuration
+   * with all its associated polar files. It waits for any crossover generation
+   * thread to complete, then determines the file path (prompting for one if
+   * none is set), and saves the boat configuration in XML format.
+   *
+   * The boat configuration contains the collection of all polar files that
+   * define the boat's performance characteristics under different sail
+   * configurations and wind conditions.
+   *
+   * On successful save, it updates any weather routing configurations using
+   * this boat through the WeatherRouting class and closes the dialog. On
+   * failure, it displays an error message.
+   *
+   * This method is called by both OnSaveBoat and OnSaveAsBoat.
+   */
   void SaveBoat();
+
+  /**
+   * Saves the current boat configuration to a new file.
+   *
+   * Clears the current file path and calls SaveBoat(), which will prompt the
+   * user for a new file name and location.
+   *
+   * @param event The command event (unused)
+   * @see SaveBoat() For the actual file saving functionality
+   */
   void OnSaveAsBoat(wxCommandEvent& event);
+  /**
+   * Saves the current boat configuration using SaveBoat().
+   *
+   * This is a direct call to SaveBoat(), which will use the existing file path
+   * if available, or prompt for a new one if not.
+   *
+   * @param event The command event (unused)
+   * @see SaveBoat() For the actual file saving functionality
+   */
   void OnSaveBoat(wxCommandEvent& event) { SaveBoat(); }
+  /**
+   * Closes the boat dialog.
+   *
+   * Hides the boat dialog without saving any changes. This method is called
+   * when the user clicks the close button or cancels the dialog.
+   *
+   * @param event The command event (unused)
+   */
   void OnClose(wxCommandEvent& event);
+  /**
+   * Loads a boat configuration file from the specified path.
+   *
+   * This method attempts to open and load a boat configuration file, which
+   * contains multiple polar files defining the boat's performance under
+   * different sail configurations. It sets the boat path, updates the dialog
+   * title to reflect the loaded file, and loads the XML configuration
+   * containing all the polar data.
+   *
+   * On success, it updates the polar list display with all polars found in the
+   * configuration.
+   *
+   * @param filename The path to the boat configuration file to load
+   * @return True if the file was loaded successfully, false otherwise
+   * @see m_Boat.OpenXML() For the actual file parsing
+   * @see RepopulatePolars() For updating the polar list display
+   */
   void LoadFile(bool switched = false);
   void OnPolarSelected(wxListEvent& event) { OnPolarSelected(); }
   void OnPolarSelected();

--- a/include/ConfigurationBatchDialog.h
+++ b/include/ConfigurationBatchDialog.h
@@ -74,10 +74,37 @@ protected:
   void OnRemoveBoat(wxCommandEvent& event);
   void On100(wxCommandEvent& event);
   void On80to120(wxCommandEvent& event);
+  /**
+   * Opens a batch configuration file.
+   *
+   * Displays a file open dialog allowing the user to select a batch
+   * configuration file, then loads the selected file. This updates the batch
+   * dialog with the source and destination positions, boat configurations, and
+   * other batch processing parameters.
+   *
+   * @param event The command event (unused)
+   */
   void OnOpen(wxCommandEvent& event);
+  /**
+   * Saves the current batch configuration to a file.
+   *
+   * Displays a file save dialog allowing the user to specify where to save the
+   * current batch configuration settings, then writes the configuration to the
+   * selected file.
+   *
+   * @param event The command event (unused)
+   */
   void OnSave(wxCommandEvent& event);
   void OnReset(wxCommandEvent& event);
   void OnInformation(wxCommandEvent& event);
+  /**
+   * Closes the batch configuration dialog and applies changes.
+   *
+   * Hides the batch configuration dialog and apply the changes. This
+   * method is called when the user clicks the OK button.
+   *
+   * @param event The command event (unused)
+   */
   void OnClose(wxCommandEvent& event);
   void OnGenerate(wxCommandEvent& event);
 

--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -842,6 +842,17 @@ public:
 
 typedef std::list<IsoChron*> IsoChronList;
 
+/**
+ * Represents a named geographic position that can be used as a start or end
+ * point for routing.
+ *
+ * RouteMapPosition stores essential information about a saved position
+ * including:
+ * - A human-readable name for the position
+ * - An optional GUID for linking to navigation objects
+ * - Latitude and longitude coordinates
+ * - A unique numeric identifier
+ */
 struct RouteMapPosition {
   RouteMapPosition(wxString n, double lat0, double lon0,
                    wxString guid = wxEmptyString)
@@ -849,11 +860,12 @@ struct RouteMapPosition {
     ID = ++s_ID;
   }
 
-  wxString Name;
-  wxString GUID;
-  double lat, lon;
-  long ID;
-  static long s_ID;
+  wxString Name;  //!< Human-readable name identifying this position
+  wxString GUID;  //!< Optional unique identifier linking to navigation objects
+  double lat;     //!< Latitude in decimal degrees
+  double lon;     //!< Longitude in decimal degrees
+  long ID;        //!< Unique numeric identifier for this position
+  static long s_ID;  //!< Static counter used to generate unique IDs
 };
 
 /**

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -86,10 +86,39 @@ protected:
   wxMenu* m_menu1;
 
   // Virtual event handlers, override them in your derived class
+  /**
+   * UI event handler for closing the dialog.
+   *
+   * Base class handler for the close menu/button action.
+   *
+   * @param event The command event
+   */
   virtual void OnClose(wxCloseEvent& event) { event.Skip(); }
   virtual void OnSize(wxSizeEvent& event) { event.Skip(); }
+  /**
+   * UI event handler for opening a configuration file.
+   *
+   * Base class handler for the open menu/button action.
+   *
+   * @param event The command event
+   */
   virtual void OnOpen(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * UI event handler for saving a configuration file.
+   *
+   * Base class handler for the save menu/button action.
+   *
+   * @param event The command event
+   */
   virtual void OnSave(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * UI event handler for saving as a configuration file.
+   *
+   * Base class handler for the "save as" menu/button action.
+   *
+   * @param event The command event
+   */
+  virtual void OnSaveAs(wxCommandEvent& event) { event.Skip(); }
   virtual void OnClose(wxCommandEvent& event) { event.Skip(); }
   virtual void OnNewPosition(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdateBoat(wxCommandEvent& event) { event.Skip(); }
@@ -328,7 +357,7 @@ protected:
   wxCheckBox* m_cbDetectBoundary;
   wxCheckBox* m_cbOptimizeTacking;
   wxCheckBox* m_cbAllowDataDeficient;
-  wxButton* m_bClose;
+  wxButton* m_bOK;
   wxPanel* m_pAdvanced;
   wxStaticText* m_staticText26;
   wxSpinCtrl* m_sMaxLatitude;
@@ -604,9 +633,21 @@ public:
   ~ReportDialogBase();
 };
 
-///////////////////////////////////////////////////////////////////////////////
-/// Class ConfigurationBatchDialogBase
-///////////////////////////////////////////////////////////////////////////////
+/**
+ * Base class for the Configuration Batch Dialog.
+ *
+ * This dialog allows users to create and manage batch configurations for
+ * weather routing. Batch processing enables automated generation of multiple
+ * routing scenarios with variations in parameters such as departure times, boat
+ * configurations, and wind settings.
+ *
+ * The dialog provides UI controls for:
+ * - Setting start and end dates/times and their spacing intervals
+ * - Managing source and destination positions
+ * - Selecting boat configurations
+ * - Configuring wind strength parameters
+ * - Executing batch generation
+ */
 class ConfigurationBatchDialogBase : public wxDialog {
 private:
 protected:
@@ -647,7 +688,7 @@ protected:
   wxButton* m_bInformation;
   wxButton* m_bReset;
   wxButton* m_bGenerate;
-  wxButton* m_bClose;
+  wxButton* m_bOK;
 
   // Virtual event handlers, overide them in your derived class
   virtual void OnOnce(wxCommandEvent& event) { event.Skip(); }

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -550,4 +550,7 @@ void ConfigurationDialog::Update() {
   m_WeatherRouting.UpdateCurrentConfigurations();
 
   if (refresh) m_WeatherRouting.GetParent()->Refresh();
+
+  // Schedule auto-save to persist any configuration changes
+  m_WeatherRouting.ScheduleAutoSave();
 }

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -32,6 +32,15 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
 
   m_mFile->AppendSeparator();
 
+  wxMenuItem* m_mSaveAs;
+  m_mSaveAs = new wxMenuItem(
+      m_mFile, wxID_ANY,
+      wxString(_("&Save As...")) + wxT('\t') + wxT("Shift+Ctrl+S"),
+      wxEmptyString, wxITEM_NORMAL);
+  m_mFile->Append(m_mSaveAs);
+
+  m_mFile->AppendSeparator();
+
   wxMenuItem* m_mClose;
   m_mClose = new wxMenuItem(m_mFile, wxID_ANY,
                             wxString(_("&Close")) + wxT('\t') + wxT("Ctrl+W"),
@@ -322,6 +331,9 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
   m_mFile->Bind(wxEVT_COMMAND_MENU_SELECTED,
                 wxCommandEventHandler(WeatherRoutingBase::OnSave), this,
                 m_mSave->GetId());
+  m_mFile->Bind(wxEVT_COMMAND_MENU_SELECTED,
+                wxCommandEventHandler(WeatherRoutingBase::OnSaveAs), this,
+                m_mSaveAs->GetId());
   m_mFile->Bind(wxEVT_COMMAND_MENU_SELECTED,
                 wxCommandEventHandler(WeatherRoutingBase::OnClose), this,
                 m_mClose->GetId());
@@ -1459,9 +1471,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
 
   fgSizer112->Add(sbData_Source, 1, wxEXPAND | wxALL, 5);
 
-  m_bClose = new wxButton(m_pBasic, wxID_ANY, _(" Close"), wxDefaultPosition,
-                          wxDefaultSize, 0);
-  fgSizer112->Add(m_bClose, 0, wxALIGN_RIGHT | wxALL, 5);
+  m_bOK = new wxButton(m_pBasic, wxID_ANY, _("OK"), wxDefaultPosition,
+                       wxDefaultSize, 0);
+  fgSizer112->Add(m_bOK, 0, wxALIGN_RIGHT | wxALL, 5);
 
   fgSizer106->Add(fgSizer112, 1, wxEXPAND | wxALL, 5);
 
@@ -2032,9 +2044,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_cbAllowDataDeficient->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(ConfigurationDialogBase::OnUpdate), NULL, this);
-  m_bClose->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                    wxCommandEventHandler(ConfigurationDialogBase::OnClose),
-                    NULL, this);
+  m_bOK->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
+                 wxCommandEventHandler(ConfigurationDialogBase::OnClose), NULL,
+                 this);
   m_sMaxLatitude->Connect(
       wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
       NULL, this);
@@ -2491,9 +2503,9 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
   m_cbAllowDataDeficient->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(ConfigurationDialogBase::OnUpdate), NULL, this);
-  m_bClose->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
-                       wxCommandEventHandler(ConfigurationDialogBase::OnClose),
-                       NULL, this);
+  m_bOK->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
+                    wxCommandEventHandler(ConfigurationDialogBase::OnClose),
+                    NULL, this);
   m_sMaxLatitude->Disconnect(
       wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
       NULL, this);
@@ -4362,9 +4374,9 @@ ConfigurationBatchDialogBase::ConfigurationBatchDialogBase(
                              wxDefaultSize, 0);
   fgSizer78->Add(m_bGenerate, 0, wxALL, 5);
 
-  m_bClose = new wxButton(this, wxID_ANY, _("Close"), wxDefaultPosition,
-                          wxDefaultSize, 0);
-  fgSizer78->Add(m_bClose, 0, wxALL, 5);
+  m_bOK = new wxButton(this, wxID_ANY, _("OK"), wxDefaultPosition,
+                       wxDefaultSize, 0);
+  fgSizer78->Add(m_bOK, 0, wxALL, 5);
 
   fgSizer76->Add(fgSizer78, 1, wxEXPAND | wxALL, 5);
 
@@ -4431,9 +4443,9 @@ ConfigurationBatchDialogBase::ConfigurationBatchDialogBase(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(ConfigurationBatchDialogBase::OnGenerate), NULL,
       this);
-  m_bClose->Connect(
-      wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(ConfigurationBatchDialogBase::OnClose), NULL, this);
+  m_bOK->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
+                 wxCommandEventHandler(ConfigurationBatchDialogBase::OnClose),
+                 NULL, this);
 }
 
 ConfigurationBatchDialogBase::~ConfigurationBatchDialogBase() {
@@ -4494,7 +4506,7 @@ ConfigurationBatchDialogBase::~ConfigurationBatchDialogBase() {
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(ConfigurationBatchDialogBase::OnGenerate), NULL,
       this);
-  m_bClose->Disconnect(
+  m_bOK->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(ConfigurationBatchDialogBase::OnClose), NULL, this);
 }


### PR DESCRIPTION
Fix for #220 


# Problem

The Weather Routing plugin currently has two limitations in its save functionality:

1. The "Save" option always shows a file dialog, effectively functioning as a "Save As" operation. This is unintuitive for users who expect standard application behavior where:
   1. "Save" updates the current file without prompting
   2. "Save As" prompts for a new location
2. In the "Save As" popup, the file is displayed without the file extension (at least on MacOS). If the user clicks the "Save" button, then the file is also named without extension.
3. Users must manually save their work, risking data loss if they forget to save before closing.

# Solution

## Proper "Save" and "Save As" Operations

Add proper "Save" and "Save As" functionality to match standard application conventions:

1. Renamed the existing OnSave method to OnSaveAs to better reflect its behavior
2. Added a new OnSave method that saves to the current file path without prompting (unless it's the first save)
4. Updated menu items and event bindings to support both save operations
5. Improved documentation to clearly explain the purpose of each method

<img width="616" alt="image" src="https://github.com/user-attachments/assets/8804cbf0-f28b-4165-928f-97d0b024af99" />


## Auto Save Functionality

1. Added automatic saving of configurations when positions or routes are modified
2. Implemented a timer-based approach that saves changes 5 seconds after modifications
3. Auto Save writes to the current working file, ensuring recent changes are preserved
4. This protects users from data loss if they forget to manually save
5. In the "Weather Routing Configuration", the "Close" button is renamed to "OK" to make it clear the configuration is saved.

# Other Changes

1. Add code comments.

# Testing

- [x] Verify "Save" properly updates the current file without prompting when a file path exists
- [x] Verify "Save" behaves like "Save As" on first save
- [x] Verify "Save As" always shows a file dialog
- [x] Verify Auto Save correctly triggers after adding, modifying, or deleting positions and routes
- [x] Verify Auto Save correctly preserves changes when reopening configurations
- [x] Verify Auto Save timer is stopped after manual save operations to prevent duplicate saves