### PR TITLE
Improve names of export/save menu items

### DIFF
--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -410,9 +410,12 @@ private:
   void OnDelete(wxCommandEvent& event);
   void OnDeleteAll(wxCommandEvent& event);
   void OnFilter(wxCommandEvent& event);
-  void OnExport(wxCommandEvent& event);
-  void OnExportRoute(wxCommandEvent& event);
-  void OnExportAll(wxCommandEvent& event);
+  /** Callback invoked when user clicks "Save as Track" menu item. */
+  void OnSaveAsTrack(wxCommandEvent& event);
+  /** Export route as GPX file. */
+  void OnExportRouteAsGPX(wxCommandEvent& event);
+  /** Callback invoked when user clicks "Save All as Tracks" menu item. */
+  void OnSaveAllAsTracks(wxCommandEvent& event);
   void OnSettings(wxCommandEvent& event);
   void OnStatistics(wxCommandEvent& event);
   void OnReport(wxCommandEvent& event);
@@ -478,7 +481,8 @@ private:
   void UpdateItem(long index, bool stateonly = false);
 
   RouteMap* SelectedRouteMap();
-  void Export(RouteMapOverlay& routemapoverlay);
+  /** Save weather routing as OpenCPN track. */
+  void SaveAsTrack(RouteMapOverlay& routemapoverlay);
   void ExportRoute(RouteMapOverlay& routemapoverlay);
   /**
    * Initiates route calculation for a specific route map overlay.

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -71,9 +71,13 @@ protected:
   wxMenuItem* m_mCompute;
   wxMenuItem* m_mComputeAll;
   wxMenuItem* m_mStop;
-  wxMenuItem* m_mExport;
-  wxMenuItem* m_mExportRoute;
-  wxMenuItem* m_mExportAll;
+  /** Menu item to save weather routing as a track in OpenCPN core. */
+  wxMenuItem* m_mSaveAsTrack;
+  /** Menu item to export weather routing as GPX file. */
+  wxMenuItem* m_mExportRouteAsGPX;
+  /** Menu item to save all weather routing configurations as tracks in OpenCPN
+   * core. */
+  wxMenuItem* m_mSaveAllAsTracks;
   wxMenu* m_mView;
   wxMenu* m_mHelp;
   wxMenuItem* m_mEdit1;
@@ -145,9 +149,12 @@ protected:
   virtual void OnComputeAll(wxCommandEvent& event) { event.Skip(); }
   virtual void OnStop(wxCommandEvent& event) { event.Skip(); }
   virtual void OnResetAll(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnExport(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnExportRoute(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnExportAll(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Save as Track" menu item. */
+  virtual void OnSaveAsTrack(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Export as GPX" menu item. */
+  virtual void OnExportRouteAsGPX(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Save All as Tracks" menu item. */
+  virtual void OnSaveAllAsTracks(wxCommandEvent& event) { event.Skip(); }
   virtual void OnFilter(wxCommandEvent& event) { event.Skip(); }
   virtual void OnSettings(wxCommandEvent& event) { event.Skip(); }
   virtual void OnStatistics(wxCommandEvent& event) { event.Skip(); }
@@ -212,8 +219,10 @@ protected:
    * signature)
    */
   virtual void OnCompute(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnExport(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnExportRoute(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Save as Track" menu item. */
+  virtual void OnSaveAsTrack(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Export as GPX" menu item. */
+  virtual void OnExportRouteAsGPX(wxCommandEvent& event) { event.Skip(); }
 
 public:
   wxSplitterWindow* m_splitter1;

--- a/manual/modules/ROOT/pages/index.adoc
+++ b/manual/modules/ROOT/pages/index.adoc
@@ -419,10 +419,10 @@ image::wr-config-boat-polar-test-xml-stats-tab.jpg[title="WR Configuration Boat 
 *[Boat]/Polar-Test.xml* file.
 * Then “*Close*” *Weather Routing Configuration* Menu.
 
-=== 13. Compute "Configuration" in WeatherRoutingConfiguration.xml Menu
+=== 13. Compute "Routing" in WeatherRoutingConfiguration.xml Menu
 
 * In the _WR WeatherRoutingConfiguration.xml_ menu, highlight the
-_Configuration_ you've created and select *Compute*.
+_Routing_ you've created and select *Compute*.
 * Now new isochrones will be created and a weather routing from Boston to Halifax will be “*completed*”.
 
 image::wr-compute.jpg[title="WR Compute",width=550,link="_images/wr-compute.jpg"]

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -137,20 +137,21 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
 
   m_mConfiguration->AppendSeparator();
 
-  m_mExport = new wxMenuItem(m_mConfiguration, wxID_ANY, wxString(_("Export")),
-                             wxEmptyString, wxITEM_NORMAL);
-  m_mConfiguration->Append(m_mExport);
+  m_mSaveAsTrack = new wxMenuItem(m_mConfiguration, wxID_ANY,
+                                  wxString(_("Save routing as track")),
+                                  wxEmptyString, wxITEM_NORMAL);
+  m_mConfiguration->Append(m_mSaveAsTrack);
 
-  m_mExportRoute =
-      new wxMenuItem(m_mConfiguration, wxID_ANY,
-                     wxString(_("E&xportRoute")) + wxT('\t') + wxT("Ctrl+X"),
-                     wxEmptyString, wxITEM_NORMAL);
-  m_mConfiguration->Append(m_mExportRoute);
+  m_mSaveAllAsTracks = new wxMenuItem(
+      m_mConfiguration, wxID_ANY, wxString(_("Save all routings as tracks")),
+      wxEmptyString, wxITEM_NORMAL);
+  m_mConfiguration->Append(m_mSaveAllAsTracks);
 
-  m_mExportAll =
-      new wxMenuItem(m_mConfiguration, wxID_ANY, wxString(_("Export All")),
-                     wxEmptyString, wxITEM_NORMAL);
-  m_mConfiguration->Append(m_mExportAll);
+  m_mExportRouteAsGPX = new wxMenuItem(
+      m_mConfiguration, wxID_ANY,
+      wxString(_("E&xport routing as GPX file")) + wxT('\t') + wxT("Ctrl+X"),
+      wxEmptyString, wxITEM_NORMAL);
+  m_mConfiguration->Append(m_mExportRouteAsGPX);
 
   m_mConfiguration->AppendSeparator();
 
@@ -160,7 +161,7 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
                              wxEmptyString, wxITEM_NORMAL);
   m_mConfiguration->Append(m_mFilter);
 
-  m_menubar3->Append(m_mConfiguration, _("&Configuration"));
+  m_menubar3->Append(m_mConfiguration, _("&Routings"));
 
   m_mView = new wxMenu();
   wxMenuItem* m_mSettings;
@@ -382,16 +383,18 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
   m_mConfiguration->Bind(wxEVT_COMMAND_MENU_SELECTED,
                          wxCommandEventHandler(WeatherRoutingBase::OnResetAll),
                          this, m_mResetAll->GetId());
-  m_mConfiguration->Bind(wxEVT_COMMAND_MENU_SELECTED,
-                         wxCommandEventHandler(WeatherRoutingBase::OnExport),
-                         this, m_mExport->GetId());
   m_mConfiguration->Bind(
       wxEVT_COMMAND_MENU_SELECTED,
-      wxCommandEventHandler(WeatherRoutingBase::OnExportRoute), this,
-      m_mExportRoute->GetId());
-  m_mConfiguration->Bind(wxEVT_COMMAND_MENU_SELECTED,
-                         wxCommandEventHandler(WeatherRoutingBase::OnExportAll),
-                         this, m_mExportAll->GetId());
+      wxCommandEventHandler(WeatherRoutingBase::OnSaveAsTrack), this,
+      m_mSaveAsTrack->GetId());
+  m_mConfiguration->Bind(
+      wxEVT_COMMAND_MENU_SELECTED,
+      wxCommandEventHandler(WeatherRoutingBase::OnExportRouteAsGPX), this,
+      m_mExportRouteAsGPX->GetId());
+  m_mConfiguration->Bind(
+      wxEVT_COMMAND_MENU_SELECTED,
+      wxCommandEventHandler(WeatherRoutingBase::OnSaveAllAsTracks), this,
+      m_mSaveAllAsTracks->GetId());
   m_mConfiguration->Bind(wxEVT_COMMAND_MENU_SELECTED,
                          wxCommandEventHandler(WeatherRoutingBase::OnFilter),
                          this, m_mFilter->GetId());
@@ -528,7 +531,7 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
 
   wxStaticBoxSizer* sbSizer29;
   sbSizer29 = new wxStaticBoxSizer(
-      new wxStaticBox(m_panel12, wxID_ANY, _("Configurations")), wxVERTICAL);
+      new wxStaticBox(m_panel12, wxID_ANY, _("Routings")), wxVERTICAL);
 
   wxFlexGridSizer* fgSizer17;
   fgSizer17 = new wxFlexGridSizer(2, 1, 0, 0);
@@ -557,12 +560,12 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
   fgSizer116->Add(m_bCompute, 0, wxALL, 5);
 
   m_bExport = new wxButton(sbSizer29->GetStaticBox(), wxID_ANY,
-                           _("&Export results as internal Track"),
-                           wxDefaultPosition, wxDefaultSize, 0);
+                           _("&Save routing as track"), wxDefaultPosition,
+                           wxDefaultSize, 0);
   fgSizer116->Add(m_bExport, 0, wxALL, 5);
 
   m_bExportRoute = new wxButton(sbSizer29->GetStaticBox(), wxID_ANY,
-                                _("Export results as GPX Route file"),
+                                _("Export routing as GPX route file"),
                                 wxDefaultPosition, wxDefaultSize, 0);
   fgSizer116->Add(m_bExportRoute, 0, wxALL, 5);
 
@@ -630,8 +633,8 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
                       wxCommandEventHandler(WeatherRoutingPanel::OnCompute),
                       NULL, this);
   m_bExport->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                     wxCommandEventHandler(WeatherRoutingPanel::OnExport), NULL,
-                     this);
+                     wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsTrack),
+                     NULL, this);
 }
 
 WeatherRoutingPanel::~WeatherRoutingPanel() {
@@ -678,9 +681,9 @@ WeatherRoutingPanel::~WeatherRoutingPanel() {
   m_bCompute->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                          wxCommandEventHandler(WeatherRoutingPanel::OnCompute),
                          NULL, this);
-  m_bExport->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
-                        wxCommandEventHandler(WeatherRoutingPanel::OnExport),
-                        NULL, this);
+  m_bExport->Disconnect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsTrack), NULL, this);
 }
 
 SettingsDialogBase::SettingsDialogBase(wxWindow* parent, wxWindowID id,


### PR DESCRIPTION
Implement some changes listed at https://github.com/rgleason/weather_routing_pi/issues/199#issuecomment-2744972266

Also related to #224

# Changes

Make the menu item names more intuitive and descriptive of their actual function.

1. Rename "Export" menu item to "Save routing as Track"
2. Rename "Export All" menu item to "Save all routings as Tracks"
3. Rename "ExportRoute" menu item to "Export routing as GPX file"
4. Rename "Configuration" menu to "Routings"
5. Rename "Configuration" panel title to "Routings"
6. Rename "Export" button to  "Save routing as Track"
7. Rename methods and fields accordingly (ease of readability and maintenance).

<img width="549" alt="image" src="https://github.com/user-attachments/assets/d1dcc0ab-7198-41f2-8d8d-9de2d207c864" />
