### PR TITLE
Improve weather routing in strong wind conditions

### DIFF
--- a/src/Polar.cpp
+++ b/src/Polar.cpp
@@ -496,7 +496,10 @@ double Polar::Speed(double twa, double tws, PolarSpeedStatus* status,
       return NAN;
     } else if (tws > wind_speeds[wind_speeds.size() - 1].tws) {
       if (status) *status = POLAR_SPEED_WIND_TOO_STRONG;
-      return NAN;
+      if (bound)
+        return NAN;  // When bound is true (default), maintain original behavior
+      // When bound is false, use the max wind speed in the polar
+      tws = wind_speeds[wind_speeds.size() - 1].tws;
     }
   }
 

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1946,9 +1946,9 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure) {
         configuration.MaxSearchAngle =
             AttributeDouble(e, "MaxSearchAngle", 120);
         configuration.MaxTrueWindKnots =
-            AttributeDouble(e, "MaxTrueWindKnots", 100);
+            AttributeDouble(e, "MaxTrueWindKnots", 50);
         configuration.MaxApparentWindKnots =
-            AttributeDouble(e, "MaxApparentWindKnots", 100);
+            AttributeDouble(e, "MaxApparentWindKnots", 50);
 
         configuration.MaxSwellMeters = AttributeDouble(e, "MaxSwellMeters", 20);
         configuration.MaxLatitude = AttributeDouble(e, "MaxLatitude", 90);
@@ -3108,8 +3108,8 @@ RouteMapConfiguration WeatherRouting::DefaultConfiguration() {
   configuration.MaxDivertedCourse = 90;
   configuration.MaxCourseAngle = 180;
   configuration.MaxSearchAngle = 120;
-  configuration.MaxTrueWindKnots = 100;
-  configuration.MaxApparentWindKnots = 100;
+  configuration.MaxTrueWindKnots = 50;      // Safety margin for wind speed
+  configuration.MaxApparentWindKnots = 50;  // Safety margin for wind speed
 
   configuration.MaxSwellMeters = 20;
   configuration.MaxLatitude = 90;


### PR DESCRIPTION
When the true wind speed exceeds the maximum in the polar data but is below the configured safety limit (MaxTrueWindKnots), the algorithm now uses the boat speed for the maximum wind in the polar instead of completely abandoning that routing option.

Related to #198 

Changes:
- Modified Polar::Speed() to use maximum wind in the polar data when wind
  is too strong and bound=false parameter is passed
- Updated Position::Propagate() and PropagateToPoint() to handle
  POLAR_SPEED_WIND_TOO_STRONG similar to POLAR_SPEED_WIND_TOO_LIGHT
- Changed default safety margin from 100 knots to a more conservative 50 knots
- Clarified code comments to explain the handling of strong wind conditions


Before this PR, the following route completes with failure:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/123d431e-dccd-4294-bb6a-f67318db1e1e" />

With this PR, the same route completes successfully:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/2f84ead1-3f26-490b-a846-617afada06ca" />

The user can still set a `MaxTrueWindKnots` value, which may cause the computation to fail.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/0a16a02a-86d5-4889-b348-b5b842010bb1" />

Alternatively, the user can increase the search angle to find a route that avoids the area of strong wind, again for the same route example:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/f75727af-6255-485e-bf40-4394f9f2e24d" />


