### PR TITLE
Night efficiency parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ add_definitions(-DUSE_S57)
 SET(SRCS
             src/weather_routing_pi.cpp
             src/WeatherRouting.cpp
+            src/SunCalculator.cpp
             src/ConfigurationDialog.cpp
             src/SettingsDialog.cpp
             src/PlotDialog.cpp
@@ -185,6 +186,7 @@ SET(SRCS
 SET (HDRS
             include/weather_routing_pi.h
             include/WeatherRouting.h
+            include/SunCalculator.h
             include/ConfigurationDialog.h
             include/SettingsDialog.h
             include/PlotDialog.h

--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -61,6 +61,29 @@ enum WeatherForecastStatus {
 };
 
 /**
+ * Represents a wind rose summary of climatological wind data for a location.
+ *
+ * This data structure holds statistical wind data typically derived from
+ * historical weather patterns. The data is organized into 8 directional sectors
+ * (at 45 degree intervals), storing both wind speeds and frequency of
+ * occurrence.
+ */
+struct climatology_wind_atlas {
+  double W[8];  //!< Probability/weight of wind occurring in each direction
+                //!< sector (0-1)
+  double
+      VW[8];  //!< Most common wind speed (in knots) for each direction sector
+  double storm;  //!< Probability of storm conditions (0-1)
+  double calm;   //!< Probability of calm conditions (0-1)
+  /**Central wind direction (in degrees) for each sector:
+   * typically [0, 45, 90, 135, 180, 225, 270, 315]
+   */
+  double directions[8];
+};
+
+class WR_GribRecordSet;
+
+/**
  * A base class representing a geographical position that is part of a route.
  *
  * RoutePoint stores the essential information about a point along a route,
@@ -75,12 +98,13 @@ enum WeatherForecastStatus {
 class RoutePoint {
 public:
   RoutePoint(double latitude = 0., double longitude = 0., int sp = -1,
-             int t = 0, bool d = false)
+             int t = 0, int dm = 0, bool data_deficient = false)
       : lat(latitude),
         lon(longitude),
         polar(sp),
         tacks(t),
-        grib_is_data_deficient(d) {}
+        grib_is_data_deficient(data_deficient),
+        data_mask(dm) {}
 
   virtual ~RoutePoint() {};
 
@@ -121,6 +145,112 @@ public:
    */
   double PropagateToPoint(double dlat, double dlon, RouteMapConfiguration& cf,
                           double& heading, int& data_mask, bool end = true);
+
+  /**
+   * Calculates boat performance based on environmental conditions and desired
+   * heading.
+   *
+   * Given a specific boat heading relative to wind, this function calculates:
+   * 1. How fast the boat will move through water (speed through water)
+   * 2. The actual direction the boat will travel through water (course through
+   * water)
+   * 3. How fast the boat will move over ground after accounting for currents
+   * (speed over ground)
+   * 4. The actual direction the boat will travel over ground (course over
+   * ground)
+   *
+   * @param configuration Boat and route configuration settings
+   * @param timeseconds Duration in seconds for the calculation
+   * @param twd [in] Wind direction over ground (degrees)
+   * @param tws [in] Wind speed over ground (knots)
+   * @param windDirOverWater [in] Wind direction through water (degrees)
+   * @param windSpeedOverWater [in] Wind speed through water (knots)
+   * @param currentDir [in] Current direction (degrees)
+   * @param currentSpeed [in] Current speed (knots)
+   * @param twa [in] True Wind Angle (TWA) (degrees)
+   * @param atlas [in] Wind climatology atlas containing probability
+   * distributions
+   * @param data_mask [in/out] Bit mask indicating data sources (GRIB,
+   * climatology, etc.)
+   * @param ctw [in] Boat's bearing relative to true wind (W+twa), initialized
+   * by caller
+   * @param stw [out] Boat speed through water
+   * @param cog [out] Boat bearing over ground
+   * @param sog [out]Boat speed over ground
+   * @param dist [out] Distance traveled over ground (nm)
+   * @param newpolar [in] Index of the polar to use from the boat's polar array
+   * @param bound [in] If true, returns NAN when wind speed is outside the range
+   * defined in the polar data. If false, extrapolates the boat speed when wind
+   * speed is outside the polar data range.
+   *
+   * @return true if computation successful, false if NaN values detected
+   */
+  bool ComputeBoatSpeed(RouteMapConfiguration& configuration,
+                        double timeseconds, double twd, double tws,
+                        double windDirOverWater, double windSpeedOverWater,
+                        double currentDir, double currentSpeed, double twa,
+                        climatology_wind_atlas& atlas, double ctw, double& stw,
+                        double& cog, double& sog, double& dist, int newpolar,
+                        bool bound = true, const char* caller = "unknown");
+
+  /**
+   * Bit flags indicating what data sources were used for wind and current
+   * calculations and other routing conditions.
+   *
+   * These flags track various aspects of each position in the routing
+   * calculation:
+   * 1. The origin of wind and current data (GRIB or climatology)
+   * 2. Whether the data was "deficient" (outside optimal time/location range)
+   * 3. Environmental conditions like day/night status
+   *
+   * The flags can be combined using bitwise OR operations to represent multiple
+   * conditions simultaneously. For example, a position at night using GRIB
+   * current data and climatology wind data would have a data_mask containing:
+   * (GRIB_CURRENT | CLIMATOLOGY_WIND | NIGHT_TIME)
+   *
+   * These flags serve multiple purposes:
+   * - Visual differentiation in the route display (different colors for data
+   * sources)
+   * - Performance adjustments (efficiency factors for different conditions)
+   * - Analytical reporting of route segments and their data quality
+   *
+   * When examining a route, these flags provide important context about the
+   * reliability and characteristics of each segment.
+   */
+  enum DataMask {
+    /** Wind data originated from GRIB files. */
+    GRIB_WIND = 1,
+
+    /** Wind data originated from climatology data. */
+    CLIMATOLOGY_WIND = 2,
+
+    /**
+     * Wind data is from GRIB but is considered "data deficient".
+     * This typically means the data is from outside the requested time
+     * or location range but was used because better data was not available.
+     */
+    DATA_DEFICIENT_WIND = 4,
+
+    /** Current data originated from GRIB files. */
+    GRIB_CURRENT = 8,
+
+    /** Current data originated from climatology data. */
+    CLIMATOLOGY_CURRENT = 16,
+
+    /**
+     * Current data is from GRIB but is considered "data deficient".
+     * This typically means the data is from outside the requested time
+     * or location range but was used because better data was not available.
+     */
+    DATA_DEFICIENT_CURRENT = 32,
+
+    /**
+     * Indicates that this position occurs during nighttime.
+     * Used to apply nighttime efficiency factor and darker display colors.
+     */
+    NIGHT_TIME = 64
+  };
+  int data_mask;
 };
 
 /*
@@ -216,7 +346,7 @@ class Position : public RoutePoint {
 public:
   Position(double latitude, double longitude, Position* p = nullptr,
            double pheading = NAN, double pbearing = NAN, int sp = -1, int t = 0,
-           int dm = 0, bool df = false);
+           int data_mask = 0, bool data_deficient = false);
   Position(Position* p);
 
   SkipPosition* BuildSkipList();
@@ -290,16 +420,6 @@ public:
   bool propagated;
   bool drawn, copied;
 
-  // used for rendering
-  enum DataMask {
-    GRIB_WIND = 1,
-    CLIMATOLOGY_WIND = 2,
-    DATA_DEFICIENT_WIND = 4,
-    GRIB_CURRENT = 8,
-    CLIMATOLOGY_CURRENT = 16,
-    DATA_DEFICIENT_CURRENT = 32
-  };
-  int data_mask;
   /** Indicates why propagation failed. */
   PropagationError propagation_error;
 
@@ -311,6 +431,11 @@ private:
   wxString GetErrorInfo() const;
   /** Get detailed error information for debugging. */
   wxString GetDetailedErrorInfo() const;
+
+  bool rk_step(double timeseconds, double cog, double dist, double twa,
+               RouteMapConfiguration& configuration, WR_GribRecordSet* grib,
+               const wxDateTime& time, int newpolar, double& rk_BG,
+               double& rk_dist, int& data_mask);
 };
 
 /**

--- a/include/SunCalculator.h
+++ b/include/SunCalculator.h
@@ -1,0 +1,96 @@
+/***************************************************************************
+ *   Copyright (C) 2016 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************/
+
+#include <wx/wx.h>
+
+enum class DayLightStatus { Day, Night };
+
+class SunCalculator {
+public:
+  // Singleton accessor with guaranteed thread safety.
+  static SunCalculator& GetInstance() {
+    static SunCalculator instance;
+    return instance;
+  }
+
+  /**
+   * Calculates sunrise and sunset times for a specific location and date
+   *
+   * This function implements the US Naval Observatory algorithm from the
+   * "Almanac for Computers, 1990" to compute sunrise and sunset times.
+   * The calculated times are returned in UTC.
+   *
+   * For locations in polar regions, where the sun may not rise or set on
+   * certain dates, the function sets the year value of the returned DateTime to
+   * 999 to indicate this condition.
+   *
+   * @param latit Latitude in decimal degrees (positive for North, negative for
+   * South)
+   * @param longit Longitude in decimal degrees (positive for East, negative for
+   * West)
+   * @param dayOfYear Reference day of year (in UTC) for which to calculate sun
+   * times
+   * @param sunrise [out] Returns the sunrise time in UTC for the specified date
+   * @param sunset [out] Returns the sunset time in UTC for the specified date
+   */
+  static void CalculateSun(double latit, double longit, int dayOfYear,
+                           wxDateTime& sunrise, wxDateTime& sunset);
+
+  /**
+   * Determines whether it's day or night at a specific location and time
+   *
+   * This function checks if a given time at a particular location is during
+   * daylight or nighttime by calculating the sunrise and sunset times. It uses
+   * an internal caching mechanism to improve performance for repeated lookups
+   * of similar coordinates and dates.
+   *
+   * The function accounts for special cases in polar regions where the sun may
+   * not rise (polar night) or set (midnight sun) on certain dates.
+   *
+   * @param lat Latitude in decimal degrees (positive for North, negative for
+   * South)
+   * @param lon Longitude in decimal degrees (positive for East, negative for
+   * West)
+   * @param time UTC time for which to determine day/night status
+   * @return DayTime enum value (Day or Night) indicating whether it's daytime
+   * or nighttime
+   */
+  DayLightStatus GetDayLightStatus(double lat, double lon,
+                                   const wxDateTime& time);
+
+private:
+  SunCalculator() = default;
+
+  struct SunTimeCache {
+    int day_of_year;
+    /** The latitude with 1-degree precision. */
+    int lat_index;
+    /** The longitude with 1-degree precision. */
+    int lon_index;
+    /** Sunrise time in UTC. */
+    wxDateTime sunrise;
+    /** Sunset time in UTC. */
+    wxDateTime sunset;
+    wxDateTime last_accessed;
+  };
+
+  static const int MAX_SUN_CACHE_SIZE = 100;
+  std::vector<SunTimeCache> m_cache;
+  wxCriticalSection m_cacheLock;
+};

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,5 +1,6 @@
 src/weather_routing_pi.cpp
 src/WeatherRouting.cpp
+src/SunCalculator.cpp
 src/ConfigurationDialog.cpp
 src/SettingsDialog.cpp
 src/PlotDialog.cpp
@@ -25,6 +26,7 @@ src/GribRecord.cpp
 src/navobj_util.cpp
 include/weather_routing_pi.h
 include/WeatherRouting.h
+include/SunCalculator.h
 include/ConfigurationDialog.h
 include/SettingsDialog.h
 include/PlotDialog.h

--- a/po/POTFILES.in.test
+++ b/po/POTFILES.in.test
@@ -1,5 +1,6 @@
 src/weather_routing_pi.cpp
 src/WeatherRouting.cpp
+src/SunCalculator.cpp
 src/ConfigurationDialog.cpp
 src/SettingsDialog.cpp
 src/PlotDialog.cpp
@@ -25,6 +26,7 @@ src/GribRecord.cpp
 src/navobj_util.cpp
 include/weather_routing_pi.h
 include/WeatherRouting.h
+include/SunCalculator.h
 include/ConfigurationDialog.h
 include/SettingsDialog.h
 include/PlotDialog.h

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -299,12 +299,8 @@ void ConfigurationDialog::SetConfigurations(
 
   SET_SPIN_VALUE(UpwindEfficiency, (int)((*it).UpwindEfficiency * 100));
   SET_SPIN_VALUE(DownwindEfficiency, (int)((*it).DownwindEfficiency * 100));
-#if 0
-  // TODO: enable when library is implemented to determine night time
-  // based on location and time.
   SET_SPIN_VALUE(NightCumulativeEfficiency,
                  (int)((*it).NightCumulativeEfficiency * 100));
-#endif
 
   m_bBlockUpdate = false;
 }
@@ -353,11 +349,7 @@ void ConfigurationDialog::OnResetAdvanced(wxCommandEvent& event) {
   m_sWindStrength->SetValue(100);
   m_sUpwindEfficiency->SetValue(100);
   m_sDownwindEfficiency->SetValue(100);
-#if 0
-  // TODO: enable when library is implemented to determine night time
-  // based on location and time.
   m_sNightCumulativeEfficiency->SetValue(100);
-#endif
   m_sTackingTime->SetValue(0);
   m_sSafetyMarginLand->SetValue(0.);
 
@@ -524,13 +516,9 @@ void ConfigurationDialog::Update() {
     if (m_sDownwindEfficiency->IsEnabled())
       configuration.DownwindEfficiency =
           m_sDownwindEfficiency->GetValue() / 100.0;
-#if 0
-    // TODO: enable when library is implemented to determine night time
-    // based on location and time.
     if (m_sNightCumulativeEfficiency->IsEnabled())
       configuration.NightCumulativeEfficiency =
           m_sNightCumulativeEfficiency->GetValue() / 100.0;
-#endif
 
     GET_CHECKBOX(AvoidCycloneTracks);
     GET_SPIN(CycloneMonths);

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -71,6 +71,7 @@
 #include "Utilities.h"
 #include "Boat.h"
 #include "RouteMap.h"
+#include "SunCalculator.h"
 #include "weather_routing_pi.h"
 
 #include "georef.h"
@@ -427,28 +428,27 @@ static inline int TestIntersectionXY(double x1, double y1, double x2, double y2,
 #define EPSILON (2e-11)
 
 Position::Position(double latitude, double longitude, Position* p,
-                   double pheading, double pbearing, int sp, int t, int dm,
-                   bool df)
-    : RoutePoint(latitude, longitude, sp, t, df),
+                   double pheading, double pbearing, int sp, int t,
+                   int data_mask, bool df)
+    : RoutePoint(latitude, longitude, sp, t, data_mask, df),
       parent_heading(pheading),
       parent_bearing(pbearing),
       parent(p),
       propagated(false),
       copied(false),
-      data_mask(dm),
       propagation_error(PROPAGATION_NO_ERROR) {
   lat -= fmod(lat, EPSILON);
   lon -= fmod(lon, EPSILON);
 }
 
 Position::Position(Position* p)
-    : RoutePoint(p->lat, p->lon, p->polar, p->tacks, p->grib_is_data_deficient),
+    : RoutePoint(p->lat, p->lon, p->polar, p->tacks, p->grib_is_data_deficient,
+                 p->data_mask),
       parent_heading(p->parent_heading),
       parent_bearing(p->parent_bearing),
       parent(p->parent),
       propagated(p->propagated),
       copied(true),
-      data_mask(p->data_mask),
       propagation_error(p->propagation_error) {}
 
 /* sufficient for routemap uses only.. is this faster than below? if not, remove
@@ -530,27 +530,6 @@ SkipPosition* Position::BuildSkipList() {
   }
   return skippoints;
 }
-
-/**
- * Represents a wind rose summary of climatological wind data for a location.
- *
- * This data structure holds statistical wind data typically derived from
- * historical weather patterns. The data is organized into 8 directional sectors
- * (at 45 degree intervals), storing both wind speeds and frequency of
- * occurrence.
- */
-struct climatology_wind_atlas {
-  double W[8];  //!< Probability/weight of wind occurring in each direction
-                //!< sector (0-1)
-  double
-      VW[8];  //!< Most common wind speed (in knots) for each direction sector
-  double storm;  //!< Probability of storm conditions (0-1)
-  double calm;   //!< Probability of calm conditions (0-1)
-  /**Central wind direction (in degrees) for each sector:
-   * typically [0, 45, 90, 135, 180, 225, 270, 315]
-   */
-  double directions[8];
-};
 
 /**
  * Retrieves wind and current data for a specific location at a particular time.
@@ -738,50 +717,16 @@ bool RoutePoint::GetCurrentData(RouteMapConfiguration& configuration,
                              currentSpeed, atlas, data_mask);
 }
 
-/**
- * Calculates boat performance based on environmental conditions and desired
- * heading.
- *
- * Given a specific boat heading relative to wind, this function calculates:
- * 1. How fast the boat will move through water (speed through water)
- * 2. The actual direction the boat will travel through water (course through
- * water)
- * 3. How fast the boat will move over ground after accounting for currents
- * (speed over ground)
- * 4. The actual direction the boat will travel over ground (course over ground)
- *
- * @param configuration Boat and route configuration settings
- * @param timeseconds Duration in seconds for the calculation
- * @param twd [in] Wind direction over ground (degrees)
- * @param tws [in] Wind speed over ground (knots)
- * @param windDirOverWater [in] Wind direction through water (degrees)
- * @param windSpeedOverWater [in] Wind speed through water (knots)
- * @param currentDir [in] Current direction (degrees)
- * @param currentSpeed [in] Current speed (knots)
- * @param twa [in] True Wind Angle (TWA) (degrees)
- * @param atlas [in] Wind climatology atlas containing probability distributions
- * @param data_mask [in] Bit mask indicating data sources (GRIB, climatology,
- * etc.)
- * @param ctw [in] Boat's bearing relative to true wind (W+twa), initialized by
- * caller
- * @param stw [out] Boat speed through water
- * @param cog [out] Boat bearing over ground
- * @param sog [out]Boat speed over ground
- * @param dist [out] Distance traveled over ground (nm)
- * @param newpolar [in] Index of the polar to use from the boat's polar array
- * @param bound [in] If true, returns NAN when wind speed is outside the range
- * defined in the polar data. If false, extrapolates the boat speed when wind
- * speed is outside the polar data range.
- *
- * @return true if computation successful, false if NaN values detected
- */
-static inline bool ComputeBoatSpeed(
+bool RoutePoint::ComputeBoatSpeed(
     RouteMapConfiguration& configuration, double timeseconds, double twd,
     double tws, double windDirOverWater, double windSpeedOverWater,
     double currentDir, double currentSpeed, double twa,
-    climatology_wind_atlas& atlas, int data_mask, double ctw, double& stw,
-    double& cog, double& sog, double& dist, int newpolar, bool bound = true,
-    const char* caller = "unknown") {
+    climatology_wind_atlas& atlas, double ctw, double& stw, double& cog,
+    double& sog, double& dist, int newpolar, bool bound, const char* caller) {
+  if (newpolar < 0 || newpolar >= configuration.boat.Polars.size()) {
+    // Sanity check - invalid polar index.
+    return false;
+  }
   Polar& polar = configuration.boat.Polars[newpolar];
   PolarSpeedStatus polar_status;
   bool used_grib = false;  // true if grib data was used, false if climatology.
@@ -846,21 +791,18 @@ static inline bool ComputeBoatSpeed(
     // Downwind sailing (90-180 degrees relative to wind)
     stw *= configuration.DownwindEfficiency;
   }
-#if 0
-  // TODO: Implement library to determine if it is night-time based on the
-  // current time and location.
-  if (configuration.NightCumulativeEfficiency != 1.0) {
-    // Apply night-time efficiency factor.
-    // First, get the current time in UTC.
-    wxDateTime time = configuration.time.ToUTC();
-    // Then, check if the current time is between sunset and sunrise
-    // for the current position.
-    if (IsNight(time, configuration, lat, lon)) {
-      // If it is night-time, apply the night-time efficiency factor.
-      stw *= configuration.NightCumulativeEfficiency;
-    }
+
+  // Determine if it's day or night at the current position and time
+  DayLightStatus dayLightStatus =
+      SunCalculator::GetInstance().GetDayLightStatus(lat, lon,
+                                                     configuration.time);
+
+  if (dayLightStatus == DayLightStatus::Night) {
+    // Apply day/night efficiency factor
+    stw *= configuration.NightCumulativeEfficiency;
+    // Set the NIGHT_TIME flag in data_mask for visual differentiation
+    data_mask |= Position::NIGHT_TIME;
   }
-#endif
 
   // Calculate boat movement over ground by combining boat speed with current.
   TransformToGroundFrame(ctw, stw, currentDir, currentSpeed, cog, sog);
@@ -892,18 +834,19 @@ static inline bool ComputeBoatSpeed(
  *
  * @return true if step was successful, false if step failed
  */
-bool rk_step(Position* p, double timeseconds, double cog, double dist,
-             double twa, RouteMapConfiguration& configuration,
-             WR_GribRecordSet* grib, const wxDateTime& time, int newpolar,
-             double& rk_BG, double& rk_dist, int& data_mask) {
+bool Position::rk_step(double timeseconds, double cog, double dist, double twa,
+                       RouteMapConfiguration& configuration,
+                       WR_GribRecordSet* grib, const wxDateTime& time,
+                       int newpolar, double& rk_BG, double& rk_dist,
+                       int& data_mask) {
   double k1_lat, k1_lon;
-  ll_gc_ll(p->lat, p->lon, cog, dist, &k1_lat, &k1_lon);
+  ll_gc_ll(lat, lon, cog, dist, &k1_lat, &k1_lon);
 
   double twd, tws, windDirOverWater, windSpeedOverWater, currentDir,
       currentSpeed;
   climatology_wind_atlas atlas;
   Position rk(k1_lat, k1_lon,
-              p->parent);  // parent so deficient data can find parent
+              parent);  // parent so deficient data can find parent
   if (!ReadWindAndCurrents(configuration, &rk, twd, tws, windDirOverWater,
                            windSpeedOverWater, currentDir, currentSpeed, atlas,
                            data_mask))
@@ -914,8 +857,8 @@ bool rk_step(Position* p, double timeseconds, double cog, double dist,
   double stw, sog;  // outputs
   if (!ComputeBoatSpeed(configuration, timeseconds, twd, tws, windDirOverWater,
                         windSpeedOverWater, currentDir, currentSpeed, twa,
-                        atlas, data_mask, ctw, stw, rk_BG, sog, rk_dist,
-                        newpolar, true /* check bounds */, "rk_step")) {
+                        atlas, ctw, stw, rk_BG, sog, rk_dist, newpolar,
+                        true /* check bounds */, "rk_step")) {
     return false;
   }
 
@@ -1085,8 +1028,8 @@ bool Position::Propagate(IsoRouteList& routelist,
 
       if (!ComputeBoatSpeed(configuration, timeseconds, twd, tws,
                             windDirOverWater, windSpeedOverWater, currentDir,
-                            currentSpeed, twa, atlas, data_mask, ctw, stw, cog,
-                            sog, dist, newpolar,
+                            currentSpeed, twa, atlas, ctw, stw, cog, sog, dist,
+                            newpolar,
                             inside_polar_bounds /* when using out-of-bound sail
                                                     plan, set bound=false */
                             ,
@@ -1103,13 +1046,13 @@ bool Position::Propagate(IsoRouteList& routelist,
             configuration.time + wxTimeSpan::Seconds(timeseconds / 2);
         wxDateTime rk_time =
             configuration.time + wxTimeSpan::Seconds(timeseconds);
-        if (!rk_step(this, timeseconds, cog, dist / 2, twa, configuration,
+        if (!rk_step(timeseconds, cog, dist / 2, twa, configuration,
                      configuration.grib, rk_time_2, newpolar, k2_BG, k2_dist,
                      data_mask) ||
-            !rk_step(this, timeseconds, cog, k2_dist / 2, twa + k2_BG - cog,
+            !rk_step(timeseconds, cog, k2_dist / 2, twa + k2_BG - cog,
                      configuration, configuration.grib, rk_time_2, newpolar,
                      k3_BG, k3_dist, data_mask) ||
-            !rk_step(this, timeseconds, cog, k3_dist, twa + k3_BG - cog,
+            !rk_step(timeseconds, cog, k3_dist, twa + k3_BG - cog,
                      configuration, configuration.grib, rk_time, newpolar,
                      k4_BG, k4_dist, data_mask)) {
           continue;
@@ -1399,8 +1342,8 @@ double RoutePoint::PropagateToPoint(double dlat, double dlon,
 
     if (!ComputeBoatSpeed(configuration, 0, twd, tws, windDirOverWater,
                           windSpeedOverWater, currentDir, currentSpeed, heading,
-                          atlas, data_mask, ctw, stw, cog, sog, dummy_dist,
-                          newpolar, inside_polar_bounds /* bound */,
+                          atlas, ctw, stw, cog, sog, dummy_dist, newpolar,
+                          inside_polar_bounds /* bound */,
                           "PropagateToPoint") ||
         ++iters == 10  // give up
     ) {

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -248,7 +248,9 @@ void RouteMapOverlay::DrawLine(RoutePoint* p1, RoutePoint* p2, piDC& dc,
     glVertex2d(p2p.x, p2p.y);
   } else
 #endif
+  {
     dc.StrokeLine(p1p.x, p1p.y, p2p.x, p2p.y);
+  }
 }
 
 void RouteMapOverlay::DrawLine(RoutePoint* p1, wxColour& color1, RoutePoint* p2,
@@ -280,7 +282,9 @@ void RouteMapOverlay::DrawLine(RoutePoint* p1, wxColour& color1, RoutePoint* p2,
     glVertex2d(p2p.x, p2p.y);
   } else
 #endif
+  {
     dc.DrawLine(p1p.x, p1p.y, p2p.x, p2p.y);
+  }
 }
 
 static inline wxColour& PositionColor(Position* p, wxColour& grib_color,
@@ -778,8 +782,9 @@ void RouteMapOverlay::RenderCourse(bool cursor_route, piDC& dc,
       wxColor c = sailingConditionColor(sailingConditionLevel(*itt));
       DrawLine(to, c, from, lc, dc, vp);
       lc = c;
-    } else
+    } else {
       DrawLine(to, from, dc, vp);
+    }
   }
 
 #ifndef __OCPN__ANDROID__

--- a/src/SunCalculator.cpp
+++ b/src/SunCalculator.cpp
@@ -1,0 +1,337 @@
+/***************************************************************************
+ *   Copyright (C) 2016 by OpenCPN development team                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************/
+
+#include <wx/wx.h>
+
+#include <math.h>
+#include <time.h>
+
+#include "SunCalculator.h"
+
+#ifndef PI
+#define PI 3.1415926535897931160E0 /* pi */
+#endif
+#define DEGREE (PI / 180.0)
+#define RADIAN (180.0 / PI)
+#define TPI (2 * PI)
+
+// Zeniths for sunset/sunrise calculation
+#define ZENITH_OFFICIAL (90.0 + 50.0 / 60.0)
+#define ZENITH_CIVIL 96.0
+#define ZENITH_NAUTICAL 102.0
+#define ZENITH_ASTRONOMICAL 108.0
+
+// Convert decimal hours in hours and minutes
+wxDateTime convHrmn(double dhr) {
+  int hr, mn;
+  hr = (int)dhr;
+  mn = (dhr - (double)hr) * 60;
+  return wxDateTime(hr, mn);
+};
+
+void SunCalculator::CalculateSun(double latit, double longit, int dayOfYear,
+                                 wxDateTime& sunrise, wxDateTime& sunset) {
+  /*
+  Source:
+  Almanac for Computers, 1990
+  published by Nautical Almanac Office
+  United States Naval Observatory
+  Washington, DC 20392
+
+  Inputs:
+  day, month, year:      date of sunrise/sunset
+  latitude, longitude:   location for sunrise/sunset
+  zenith:                Sun's zenith for sunrise/sunset
+  official      = 90 degrees 50'
+  civil        = 96 degrees
+  nautical     = 102 degrees
+  astronomical = 108 degrees
+
+  NOTE: longitude is positive for East and negative for West
+  NOTE: the algorithm assumes the use of a calculator with the
+  trig functions in "degree" (rather than "radian") mode. Most
+  programming languages assume radian arguments, requiring back
+  and forth conversions. The factor is 180/pi. So, for instance,
+  the equation RA = atan(0.91764 * tan(L)) would be coded as RA
+  = (180/pi)*atan(0.91764 * tan((pi/180)*L)) to give a degree
+  answer with a degree input for L.
+
+  1. first calculate the day of the year
+
+  N1 = floor(275 * month / 9)
+  N2 = floor((month + 9) / 12)
+  N3 = (1 + floor((year - 4 * floor(year / 4) + 2) / 3))
+  N = N1 - (N2 * N3) + day - 30
+  */
+  /*
+  2. convert the longitude to hour value and calculate an approximate time
+
+  lngHour = longitude / 15
+
+  if rising time is desired:
+  t = N + ((6 - lngHour) / 24)
+  if setting time is desired:
+  t = N + ((18 - lngHour) / 24)
+  */
+  double lngHour = longit / 15;
+  double tris = dayOfYear + ((6 - lngHour) / 24);
+  double tset = dayOfYear + ((18 - lngHour) / 24);
+  /*
+
+  3. calculate the Sun's mean anomaly
+
+  M = (0.9856 * t) - 3.289
+  */
+  double mris = (0.9856 * tris) - 3.289;
+  double mset = (0.9856 * tset) - 3.289;
+  /*
+  4. calculate the Sun's true longitude
+
+  L = M + (1.916 * sin(M)) + (0.020 * sin(2 * M)) + 282.634
+  NOTE: L potentially needs to be adjusted into the range [0,360) by
+  adding/subtracting 360
+  */
+  double lris = mris + (1.916 * sin(DEGREE * mris)) +
+                (0.020 * sin(2 * DEGREE * mris)) + 282.634;
+  if (lris > 360) lris -= 360;
+  if (lris < 0) lris += 360;
+  double lset = mset + (1.916 * sin(DEGREE * mset)) +
+                (0.020 * sin(2 * DEGREE * mset)) + 282.634;
+  if (lset > 360) lset -= 360;
+  if (lset < 0) lset += 360;
+  /*
+  5a. calculate the Sun's right ascension
+
+  RA = atan(0.91764 * tan(L))
+  NOTE: RA potentially needs to be adjusted into the range [0,360) by
+  adding/subtracting 360
+  */
+  double raris = RADIAN * atan(0.91764 * tan(DEGREE * lris));
+  if (raris > 360) raris -= 360;
+  if (raris < 0) raris += 360;
+  double raset = RADIAN * atan(0.91764 * tan(DEGREE * lset));
+  if (raset > 360) raset -= 360;
+  if (raset < 0) raset += 360;
+  /*
+  5b. right ascension value needs to be in the same quadrant as L
+
+  Lquadrant  = (floor( L/90)) * 90
+  RAquadrant = (floor(RA/90)) * 90
+  RA = RA + (Lquadrant - RAquadrant)
+  */
+  double lqris = (floor(lris / 90)) * 90;
+  double raqris = (floor(raris / 90)) * 90;
+  raris = raris + (lqris - raqris);
+  double lqset = (floor(lset / 90)) * 90;
+  double raqset = (floor(raset / 90)) * 90;
+  raset = raset + (lqset - raqset);
+  /*
+  5c. right ascension value needs to be converted into hours
+
+  RA = RA / 15
+  */
+  raris = raris / 15;
+  raset = raset / 15;
+  /*
+  6. calculate the Sun's declination
+
+  sinDec = 0.39782 * sin(L)
+  cosDec = cos(asin(sinDec))
+  */
+  double sinDecris = 0.39782 * sin(DEGREE * lris);
+  double cosDecris = cos(asin(sinDecris));
+  double sinDecset = 0.39782 * sin(DEGREE * lset);
+  double cosDecset = cos(asin(sinDecset));
+  /*
+  7a. calculate the Sun's local hour angle
+
+  cosH = (cos(zenith) - (sinDec * sin(latitude))) / (cosDec * cos(latitude))
+
+  if (cosH >  1)
+  the sun never rises on this location (on the specified date)
+  if (cosH < -1)
+  the sun never sets on this location (on the specified date)
+  */
+  double cosZenith = cos(DEGREE * ZENITH_OFFICIAL);
+  double coshris = (cosZenith - (sinDecris * sin(DEGREE * latit))) /
+                   (cosDecris * cos(DEGREE * latit));
+  double coshset = (cosZenith - (sinDecset * sin(DEGREE * latit))) /
+                   (cosDecset * cos(DEGREE * latit));
+  bool neverrises = false;
+  if (coshris > 1) neverrises = true;
+  if (coshris < -1)
+    neverrises = true;  // nohal - it's cosine - even value lower than -1 is
+  // ilegal... correct me if i'm wrong
+  bool neversets = false;
+  if (coshset < -1) neversets = true;
+  if (coshset > 1)
+    neversets = true;  // nohal - it's cosine - even value greater than 1 is
+  // ilegal... correct me if i'm wrong
+  /*
+  7b. finish calculating H and convert into hours
+
+  if if rising time is desired:
+  H = 360 - acos(cosH)
+  if setting time is desired:
+  H = acos(cosH)
+
+  H = H / 15
+  */
+  double hris = 360 - RADIAN * acos(coshris);
+  hris = hris / 15;
+  double hset = RADIAN * acos(coshset);
+  hset = hset / 15;
+  /*
+  8. calculate local mean time of rising/setting
+
+  T = H + RA - (0.06571 * t) - 6.622
+  */
+  tris = hris + raris - (0.06571 * tris) - 6.622;
+  tset = hset + raset - (0.06571 * tset) - 6.622;
+  /*
+  9. adjust back to UTC
+
+  UT = T - lngHour
+  NOTE: UT potentially needs to be adjusted into the range [0,24) by
+  adding/subtracting 24
+  */
+  double utris = tris - lngHour;
+  if (utris > 24) utris -= 24;
+  if (utris < 0) utris += 24;
+  double utset = tset - lngHour;
+  if (utset > 24) utset -= 24;
+  if (utset < 0) utset += 24;
+
+  sunrise = convHrmn(utris);
+  if (neverrises) sunrise.SetYear(999);
+  sunset = convHrmn(utset);
+  if (neversets) sunset.SetYear(999);
+  /*
+  Optional:
+  10. convert UT value to local time zone of latitude/longitude
+
+  localT = UT + localOffset
+  */
+}
+
+/**
+ * Determines if a given time at a particular location is daytime or nighttime.
+ *
+ * Uses the US Naval Observatory algorithm implemented in calculateSun()
+ * and caches results to improve performance during routing calculations.
+ *
+ * @param lat Latitude of the location (-90 to 90)
+ * @param lon Longitude of the location (-180 to 180)
+ * @param time UTC time to evaluate
+ * @return DayTime enum indicating whether it's day or night
+ */
+DayLightStatus SunCalculator::GetDayLightStatus(double lat, double lon,
+                                                const wxDateTime& time) {
+  // Use coarse-grained grid for caching (1-degree precision)
+  // This reduces cache misses while maintaining acceptable accuracy
+  int lat_index = static_cast<int>(round(lat));
+  int lon_index = static_cast<int>(round(lon));
+  int day_of_year = time.GetDayOfYear();
+  int hourOfDay = time.GetHour(wxDateTime::UTC);
+
+  wxCriticalSectionLocker lock(m_cacheLock);
+
+  // Check cache first
+  auto& cache = m_cache;
+  for (auto& entry : cache) {
+    if (entry.day_of_year == day_of_year && entry.lat_index == lat_index &&
+        entry.lon_index == lon_index) {
+      // Cache hit - update access time
+      entry.last_accessed = wxDateTime::Now();
+
+      // Determine if it's day or night
+      wxDateTime sunrise = entry.sunrise;
+      wxDateTime sunset = entry.sunset;
+
+      // Handle edge cases
+      if (sunrise.GetYear() == 999) {
+        // Sun never rises (polar night)
+        return DayLightStatus::Night;
+      } else if (sunset.GetYear() == 999) {
+        // Sun never sets (midnight sun)
+        return DayLightStatus::Day;
+      }
+
+      // Normal case: compare current time to sunrise/sunset
+      int sunriseHour = sunrise.GetHour(wxDateTime::UTC);
+      int sunsetHour = sunset.GetHour(wxDateTime::UTC);
+      if (sunsetHour < sunriseHour) {
+        // Sun sets after midnight
+        return (hourOfDay >= sunriseHour || hourOfDay < sunsetHour)
+                   ? DayLightStatus::Day
+                   : DayLightStatus::Night;
+      } else {
+        // Normal case: sunrise and sunset on same day
+        return (hourOfDay >= sunriseHour && hourOfDay < sunsetHour)
+                   ? DayLightStatus::Day
+                   : DayLightStatus::Night;
+      }
+    }
+  }
+  // Cache miss - calculate new values
+  wxDateTime sunrise, sunset;
+  CalculateSun(lat, lon, day_of_year, sunrise, sunset);
+
+  // Add to cache using LRU replacement policy if needed
+  if (cache.size() >= MAX_SUN_CACHE_SIZE) {
+    // Find least recently accessed entry
+    auto oldest =
+        std::min_element(cache.begin(), cache.end(),
+                         [](const SunTimeCache& a, const SunTimeCache& b) {
+                           return a.last_accessed < b.last_accessed;
+                         });
+
+    // Replace it with new entry
+    oldest->day_of_year = day_of_year;
+    oldest->lat_index = lat_index;
+    oldest->lon_index = lon_index;
+    oldest->sunrise = sunrise;
+    oldest->sunset = sunset;
+    oldest->last_accessed = wxDateTime::Now();
+  } else {
+    // Add new entry
+    cache.push_back({day_of_year, lat_index, lon_index, sunrise, sunset,
+                     wxDateTime::Now()});
+  }
+
+  // Determine day/night status with new calculation
+  if (sunrise.GetYear() == 999) {
+    return DayLightStatus::Night;  // Polar night
+  } else if (sunset.GetYear() == 999) {
+    return DayLightStatus::Day;  // Midnight sun
+  }
+  int sunriseHour = sunrise.GetHour(wxDateTime::UTC);
+  int sunsetHour = sunset.GetHour(wxDateTime::UTC);
+  if (sunsetHour < sunriseHour) {
+    // Sun sets after midnight
+    return (hourOfDay >= sunriseHour || hourOfDay < sunsetHour)
+               ? DayLightStatus::Day
+               : DayLightStatus::Night;
+  } else {
+    // Normal case: sunrise and sunset on same day
+    return (hourOfDay >= sunriseHour && hourOfDay < sunsetHour)
+               ? DayLightStatus::Day
+               : DayLightStatus::Night;
+  }
+}

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1972,12 +1972,8 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure) {
             AttributeDouble(e, "UpwindEfficiency", 1.);
         configuration.DownwindEfficiency =
             AttributeDouble(e, "DownwindEfficiency", 1.);
-#if 0
-        // TODO: enable this when library is implemented to determine the
-        // sunrise/sunset times based on the boat's position.
         configuration.NightCumulativeEfficiency =
             AttributeDouble(e, "NightCumulativeEfficiency", 1.);
-#endif
 
         configuration.DetectLand = AttributeBool(e, "DetectLand", true);
         configuration.SafetyMarginLand =
@@ -2104,12 +2100,8 @@ void WeatherRouting::SaveXML(wxString filename) {
     c->SetDoubleAttribute("UpwindEfficiency", configuration.UpwindEfficiency);
     c->SetDoubleAttribute("DownwindEfficiency",
                           configuration.DownwindEfficiency);
-#if 0
-    // TODO: enable after library is implemented to determine the sunrise/sunset
-    // times based on the boat's position.
     c->SetDoubleAttribute("NightCumulativeEfficiency",
                           configuration.NightCumulativeEfficiency);
-#endif
 
     c->SetAttribute("DetectLand", configuration.DetectLand);
     c->SetAttribute("SafetyMarginLand", configuration.SafetyMarginLand);

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1851,9 +1851,6 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   fgSizerEfficiency->Add(m_staticTextDownwindPC, 0,
                          wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-#if 0
-  // TODO: enable night efficiency settings after implementing library
-  // to calculate sunrise/sunset times for a given location.
   wxStaticText* m_staticTextNight =
       new wxStaticText(sbEfficiency->GetStaticBox(), wxID_ANY, _("Night"),
                        wxDefaultPosition, wxDefaultSize, 0);
@@ -1875,7 +1872,6 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_staticTextNightPC->Wrap(-1);
   fgSizerEfficiency->Add(m_staticTextNightPC, 0,
                          wxALIGN_CENTER_VERTICAL | wxALL, 5);
-#endif
 
   sbEfficiency->Add(fgSizerEfficiency, 1, wxEXPAND, 5);
   fgSizer109->Add(sbEfficiency, 1, wxEXPAND | wxALL, 5);
@@ -2408,13 +2404,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sDownwindEfficiency->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
-#if 0
-  // TODO: enable night efficiency settings after implementing library
-  // to calculate sunrise/sunset times for a given location.
   m_sNightCumulativeEfficiency->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
-#endif
   m_sFromDegree->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
@@ -2879,13 +2871,9 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
   m_sDownwindEfficiency->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
-#if 0
-  // TODO: enable night efficiency settings after implementing library
-  // to calculate sunrise/sunset times for a given location.
   m_sNightCumulativeEfficiency->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
-#endif
   m_sFromDegree->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);


### PR DESCRIPTION
# Overview

This PR implements a night efficiency parameter that adjusts boat performance during nighttime conditions. The implementation includes:

1. A new SunCalculator class that calculates sunrise and sunset times for any location and date using the US Naval Observatory algorithm from the "Almanac for Computers, 1990" - obtained from OpenCPN core.
2. Enhancements to the route planning system to apply the night efficiency factor when sailing during nighttime hours

Other changes:

3. Moving the ComputeBoatSpeed function from a standalone static function to a method of the RoutePoint class for better organization and encapsulation.
4. Add sanity check in `ComputeBoatSpeed` in case polar index is out of bounds.

# Example

Below is a screenshot showing the impact of `NightCumulativeEfficiency`. I've intentionally set the parameter to a very low value (10%) to show the effect.

<img width="806" alt="image" src="https://github.com/user-attachments/assets/d989b458-5bd0-477f-91a9-5a79d709175d" />

# Follow-Up Tasks

It would be nice to render the day vs night isochrons with a different style.
