### PR TITLE
Improve the visibility of the boat indicator in a routing.

### DIFF
--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -281,10 +281,10 @@ public:
   wxDateTime time;
   /** The time in seconds from the previous position to this position. */
   double delta;
-  double sog;  //!< Speed of boat over ground (knots).
-  double cog;  //!< Course of boat over ground (degrees).
-  double stw;  //!< Speed of boat through water (knots).
-  double ctw;  //!< Course of boat through water (degrees).
+  double sog;  //!< Speed Over Ground (SOG) in knots.
+  double cog;  //!< Course Over Ground in degrees.
+  double stw;  //!< Speed of boat through water in knots.
+  double ctw;  //!< Course of boat through water in degrees.
   /** Wind speed relative to the water's frame of reference in knots. */
   double VW;
   /**
@@ -294,12 +294,12 @@ public:
    * and the wind direction in degrees.
    */
   double twa;
-  double tws;           //!< Velocity of wind over ground (knots).
-  double twd;           //!< Wind direction over ground.
-  double currentSpeed;  //!< Velocity of current over ground (knots).
-  double currentDir;    //!< Sea current direction over ground.
-  double WVHT;          //!< Swell height (meters).
-  double VW_GUST;       //!< Gust wind speed (knots).
+  double tws;           //!< True Wind Speed (TWS) over ground in knots.
+  double twd;           //!< True Wind Direction (TWD) over ground in degrees.
+  double currentSpeed;  //!< Velocity of current over ground in knots.
+  double currentDir;    //!< Sea current direction over ground in degrees.
+  double WVHT;          //!< Swell height in meters.
+  double VW_GUST;       //!< Gust wind speed in knots.
 };
 
 class SkipPosition;

--- a/include/RouteMapOverlay.h
+++ b/include/RouteMapOverlay.h
@@ -295,12 +295,13 @@ private:
   /**
    * Renders a single isochron route.
    * @param r Pointer to the route to render.
+   * @param time The currently selected time in the GRIB timeline.
    * @param grib_color Color for grib-based segments.
    * @param climatology_color Color for climatology-based segments.
    * @param dc Device context for drawing.
    * @param vp ViewPort for coordinate transformations.
    */
-  void RenderIsoRoute(IsoRoute* r, wxColour& grib_color,
+  void RenderIsoRoute(IsoRoute* r, wxDateTime time, wxColour& grib_color,
                       wxColour& climatology_color, piDC& dc,
                       PlugIn_ViewPort& vp);
 
@@ -398,16 +399,66 @@ private:
   /** Last cursor longitude. */
   double last_cursor_lon;
 
-  /** Pointer to the last cursor position. */
+  /**
+   * Position on the route closest to where the user's cursor is hovering.
+   *
+   * This variable tracks which position on the computed route is nearest to the
+   * current cursor location on the chart. It's used to display
+   * position-specific data in the Cursor Position dialog and for visual
+   * highlighting on the chart.
+   *
+   * @see UpdateCursorPositionDialog() For updating the UI with this position's
+   * data
+   */
   Position* last_cursor_position;
 
-  /** Pointer to the destination position. */
+  /**
+   * The final computed position that exactly matches the destination
+   * coordinates.
+   *
+   * This position is created and set only when route propagation successfully
+   * reaches the exact destination point. If the route calculation reaches the
+   * area but can't precisely hit the destination (due to land barriers, etc.),
+   * this will remain null while last_destination_position will be set to the
+   * closest reachable position.
+   *
+   * @see UpdateDestination() Where this is set upon successful route completion
+   */
   Position* destination_position;
 
-  /** Pointer to the last destination position. */
+  /**
+   * Best position reached toward the destination during route calculation.
+   *
+   * This stores either:
+   * 1. The exact destination position (destination_position) if reached
+   * successfully
+   * 2. The closest calculated position to the destination if exact arrival
+   * isn't possible
+   *
+   * It's always set regardless of whether the exact destination is reached,
+   * making it the reliable reference for the route's endpoint in the UI and
+   * reporting functions.
+   *
+   * @see UpdateDestination() For the logic determining which position to use
+   */
   Position* last_destination_position;
 
-  /** Time at the cursor position. */
+  /**
+   * The timestamp when the cursor position is at the given point on the route.
+   *
+   * When the user hovers over a point on the calculated route, this variable
+   * stores the projected time when the vessel would reach that specific
+   * position according to the route calculation. This time value is used in the
+   * CursorPositionDialog to display temporal information alongside spatial
+   * coordinates.
+   *
+   * This time is retrieved from the RouteMapOverlay during cursor interaction
+   * via the GetLastCursorTime() method and is updated whenever the cursor moves
+   * to a different position on the route.
+   *
+   * The value is only valid when last_cursor_position is non-null, indicating
+   * that the cursor is currently over a valid position on the route.
+   */
   wxDateTime m_cursor_time;
 
   /** End time of the route. */

--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -329,7 +329,26 @@ public:
   void CursorRouteChanged();
   void UpdateColumns();
 
+  /**
+   * Updates the Cursor Position dialog with data from the currently selected
+   * route.
+   *
+   * This method refreshes the CursorPositionDialog with information about the
+   * route position closest to where the user's cursor is hovering on the chart.
+   *
+   * This method is called:
+   * 1. When cursor movements trigger position changes
+   * 2. Whenever the dialog is shown
+   * 3. Periodically during route rendering to keep information current
+   */
   void UpdateCursorPositionDialog();
+  /**
+   * Updates the Route Position dialog with detailed information about a
+   * position along the route.
+   *
+   * This method refreshes the RoutePositionDialog with information about the
+   * route position closest to the user's cursor on the chart.
+   */
   void UpdateRoutePositionDialog();
 
   /**
@@ -534,8 +553,49 @@ private:
 
   wxSize m_size;
 
-  // CUSTOMIZATION
+  /**
+   * Pointer to the closest Position object on the route to the user's cursor
+   * location.
+   *
+   * This member variable is used to track and display the position on the
+   * computed weather route closest to where the user has placed their cursor on
+   * the chart. It's utilized by:
+   *
+   * 1. The RoutePositionDialog to display detailed data about this specific
+   * route point
+   * 2. The Render method to visually highlight this position on the chart
+   *
+   * When the user moves their cursor over the chart, this pointer is updated to
+   * point to the closest calculated position on the route by
+   * getClosestRoutePositionFromCursor(). If a direct Position* cannot be
+   * obtained but plot data is available, a temporary position (m_savedPosition)
+   * may be used instead.
+   *
+   * This allows the user to explore detailed information about any point along
+   * the computed route by simply moving their cursor near that point on the
+   * chart.
+   *
+   * @see UpdateRoutePositionDialog() For the method that updates this pointer
+   * @see RouteMapOverlay::getClosestRoutePositionFromCursor() For the
+   * calculation method
+   * @see RoutePositionDialog For the UI that displays data from this position
+   */
   RoutePoint* m_positionOnRoute;
+  /**
+   * Temporary storage for position data when a direct Position* pointer is
+   * unavailable.
+   *
+   * When getClosestRoutePositionFromCursor() can find plot data for a point but
+   * not a direct Position* pointer, this member variable stores the position
+   * information to ensure the UI can still display details about that point on
+   * the route.
+   *
+   * This prevents information loss in situations where the route data is
+   * available in one form (PlotData) but not another (Position*).
+   *
+   * @see m_positionOnRoute The main position pointer this serves as a backup
+   * for
+   */
   RoutePoint m_savedPosition;
 };
 

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -52,11 +52,28 @@
 
 #include "wxWTranslateCatalog.h"
 
-///////////////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////////////////
-/// Class WeatherRoutingBase
-///////////////////////////////////////////////////////////////////////////////
+/**
+ * Base class for the Weather Routing plugin's main interface.
+ *
+ * WeatherRoutingBase provides the foundational UI framework for the Weather
+ * Routing plugin, defining the menu structure, event handlers, and basic window
+ * layout.
+ *
+ * The class defines:
+ * - The main menu structure with File, Position, Configuration, and View
+ * options
+ * - Menu items for all major operations (Open, Save, Compute, etc.)
+ * - Event handler declarations for all UI interactions
+ * - Context menu for right-click operations
+ *
+ * This base UI class establishes the interface's overall structure but
+ * delegates the implementation of business logic to the derived WeatherRouting
+ * class.
+ *
+ * @see WeatherRouting The implementation class that inherits from this base
+ * class
+ * @see WeatherRoutingPanel The panel containing the list controls and buttons
+ */
 class WeatherRoutingBase : public wxFrame {
 private:
 protected:
@@ -161,6 +178,16 @@ protected:
   virtual void OnReport(wxCommandEvent& event) { event.Skip(); }
   virtual void OnPlot(wxCommandEvent& event) { event.Skip(); }
   virtual void OnCursorPosition(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * Event handler for toggling display of the Route Position dialog.
+   *
+   * This base class handler for the route position dialog toggle. It is
+   * overridden in the derived WeatherRouting class to handle the actual UI
+   * state changes.
+   *
+   * @param event The command event (unused but required by event handler
+   * signature)
+   */
   virtual void OnRoutePosition(wxCommandEvent& event) { event.Skip(); }
   virtual void OnInformation(wxCommandEvent& event) { event.Skip(); }
   virtual void OnManual(wxCommandEvent& event) { event.Skip(); }

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -37,8 +37,6 @@
 Json::Value g_ReceivedJSONMsg;
 wxString g_ReceivedMessage;
 
-double g_WINDipFactor;
-
 // Define minimum and maximum versions of the grib plugin supported
 #define GRIB_MAX_MAJOR 5
 #define GRIB_MAX_MINOR 0
@@ -159,8 +157,6 @@ int weather_routing_pi::Init() {
       new wxMenuItem(&dummy_menu, -1, _("Weather Route Analysis")), this,
       "Route");
   // SetCanvasMenuItemViz(m_route_menu_id, false, "Route");
-
-  g_WINDipFactor = 1.0;
 
   //    And load the configuration items
   LoadConfig();
@@ -390,16 +386,6 @@ void weather_routing_pi::SetPluginMessage(wxString& message_id,
           // char*)root[wxS("GUID")].AsString().mb_str());
         }
       }
-    }
-  }
-  // Capture some OCPN core parameters, if present
-  else if (message_id == _T("OpenCPN Config")) {
-    Json::Reader r;
-    Json::Value v;
-    r.parse(static_cast<std::string>(message_body), v);
-
-    if (v["OpenCPN Display DIP Scale Factor"].isDouble()) {
-      g_WINDipFactor = v["OpenCPN Display DIP Scale Factor"].asDouble();
     }
   }
 }


### PR DESCRIPTION
Fix #112 

1. Make the circle representing the project boat position bigger and thicker.
2. Highlight the isochron matching the selected GRIB time.
3. Add code comments.

Example:
1. The projected boat location is bigger and thicker.
2. The isochron for that selected time is thicker (blue line in this example)

<img width="777" alt="image" src="https://github.com/user-attachments/assets/0e4c936e-52b4-40ae-bb84-bea2ebcfba35" />

