### PR TITLE
Menu and button to Save as route

### DIFF
--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -431,6 +431,8 @@ private:
   void OnFilter(wxCommandEvent& event);
   /** Callback invoked when user clicks "Save as Track" menu item. */
   void OnSaveAsTrack(wxCommandEvent& event);
+  /** Callback invoked when user clicks "Save as Route" menu item. */
+  void OnSaveAsRoute(wxCommandEvent& event);
   /** Export route as GPX file. */
   void OnExportRouteAsGPX(wxCommandEvent& event);
   /** Callback invoked when user clicks "Save All as Tracks" menu item. */
@@ -502,6 +504,8 @@ private:
   RouteMap* SelectedRouteMap();
   /** Save weather routing as OpenCPN track. */
   void SaveAsTrack(RouteMapOverlay& routemapoverlay);
+  /** Save weather routing as OpenCPN route. */
+  void SaveAsRoute(RouteMapOverlay& routemapoverlay);
   void ExportRoute(RouteMapOverlay& routemapoverlay);
   /**
    * Initiates route calculation for a specific route map overlay.

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -90,6 +90,8 @@ protected:
   wxMenuItem* m_mStop;
   /** Menu item to save weather routing as a track in OpenCPN core. */
   wxMenuItem* m_mSaveAsTrack;
+  /** Menu item to save weather routing as a route in OpenCPN core. */
+  wxMenuItem* m_mSaveAsRoute;
   /** Menu item to export weather routing as GPX file. */
   wxMenuItem* m_mExportRouteAsGPX;
   /** Menu item to save all weather routing configurations as tracks in OpenCPN
@@ -168,6 +170,8 @@ protected:
   virtual void OnResetAll(wxCommandEvent& event) { event.Skip(); }
   /** Callback invoked when user clicks "Save as Track" menu item. */
   virtual void OnSaveAsTrack(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Save as Route" menu item. */
+  virtual void OnSaveAsRoute(wxCommandEvent& event) { event.Skip(); }
   /** Callback invoked when user clicks "Export as GPX" menu item. */
   virtual void OnExportRouteAsGPX(wxCommandEvent& event) { event.Skip(); }
   /** Callback invoked when user clicks "Save All as Tracks" menu item. */
@@ -248,6 +252,8 @@ protected:
   virtual void OnCompute(wxCommandEvent& event) { event.Skip(); }
   /** Callback invoked when user clicks "Save as Track" menu item. */
   virtual void OnSaveAsTrack(wxCommandEvent& event) { event.Skip(); }
+  /** Callback invoked when user clicks "Save as Route" menu item. */
+  virtual void OnSaveAsRoute(wxCommandEvent& event) { event.Skip(); }
   /** Callback invoked when user clicks "Export as GPX" menu item. */
   virtual void OnExportRouteAsGPX(wxCommandEvent& event) { event.Skip(); }
 
@@ -263,7 +269,8 @@ public:
    */
   wxListCtrl* m_lWeatherRoutes;
   wxButton* m_bCompute;
-  wxButton* m_bExport;
+  wxButton* m_bSaveAsTrack;
+  wxButton* m_bSaveAsRoute;
   wxButton* m_bExportRoute;
   wxGauge* m_gProgress;
 

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -137,15 +137,20 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
 
   m_mConfiguration->AppendSeparator();
 
-  m_mSaveAsTrack = new wxMenuItem(m_mConfiguration, wxID_ANY,
-                                  wxString(_("Save routing as track")),
-                                  wxEmptyString, wxITEM_NORMAL);
+  m_mSaveAsTrack =
+      new wxMenuItem(m_mConfiguration, wxID_ANY, wxString(_("Save as track")),
+                     wxEmptyString, wxITEM_NORMAL);
   m_mConfiguration->Append(m_mSaveAsTrack);
 
-  m_mSaveAllAsTracks = new wxMenuItem(
-      m_mConfiguration, wxID_ANY, wxString(_("Save all routings as tracks")),
-      wxEmptyString, wxITEM_NORMAL);
+  m_mSaveAllAsTracks = new wxMenuItem(m_mConfiguration, wxID_ANY,
+                                      wxString(_("Save all as tracks")),
+                                      wxEmptyString, wxITEM_NORMAL);
   m_mConfiguration->Append(m_mSaveAllAsTracks);
+
+  m_mSaveAsRoute =
+      new wxMenuItem(m_mConfiguration, wxID_ANY, wxString(_("Save as route")),
+                     wxEmptyString, wxITEM_NORMAL);
+  m_mConfiguration->Append(m_mSaveAsRoute);
 
   m_mExportRouteAsGPX = new wxMenuItem(
       m_mConfiguration, wxID_ANY,
@@ -389,6 +394,10 @@ WeatherRoutingBase::WeatherRoutingBase(wxWindow* parent, wxWindowID id,
       m_mSaveAsTrack->GetId());
   m_mConfiguration->Bind(
       wxEVT_COMMAND_MENU_SELECTED,
+      wxCommandEventHandler(WeatherRoutingBase::OnSaveAsRoute), this,
+      m_mSaveAsRoute->GetId());
+  m_mConfiguration->Bind(
+      wxEVT_COMMAND_MENU_SELECTED,
       wxCommandEventHandler(WeatherRoutingBase::OnExportRouteAsGPX), this,
       m_mExportRouteAsGPX->GetId());
   m_mConfiguration->Bind(
@@ -547,7 +556,7 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
 
   wxFlexGridSizer* fgSizer116;
   fgSizer116 = new wxFlexGridSizer(1, 0, 0, 0);
-  fgSizer116->AddGrowableCol(2);
+  fgSizer116->AddGrowableCol(3);
   fgSizer116->SetFlexibleDirection(wxBOTH);
   fgSizer116->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
@@ -559,15 +568,22 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
         "configuration"));
   fgSizer116->Add(m_bCompute, 0, wxALL, 5);
 
-  m_bExport = new wxButton(sbSizer29->GetStaticBox(), wxID_ANY,
-                           _("&Save routing as track"), wxDefaultPosition,
-                           wxDefaultSize, 0);
-  m_bExport->SetToolTip(_(
-      "Save the selected routing as a track in the 'Route & Mark' Manager"));
-  fgSizer116->Add(m_bExport, 0, wxALL, 5);
+  m_bSaveAsTrack =
+      new wxButton(sbSizer29->GetStaticBox(), wxID_ANY, _("&Save as track"),
+                   wxDefaultPosition, wxDefaultSize, 0);
+  m_bSaveAsTrack->SetToolTip(
+      _("Save the selected routing as a track in the 'Route & Mark' Manager"));
+  fgSizer116->Add(m_bSaveAsTrack, 0, wxALL, 5);
+
+  m_bSaveAsRoute =
+      new wxButton(sbSizer29->GetStaticBox(), wxID_ANY, _("Save as &route"),
+                   wxDefaultPosition, wxDefaultSize, 0);
+  m_bSaveAsRoute->SetToolTip(
+      _("Save the selected routing as a route in the 'Route & Mark' Manager"));
+  fgSizer116->Add(m_bSaveAsRoute, 0, wxALL, 5);
 
   m_bExportRoute = new wxButton(sbSizer29->GetStaticBox(), wxID_ANY,
-                                _("Export routing as GPX route file"),
+                                _("Export as GPX route file"),
                                 wxDefaultPosition, wxDefaultSize, 0);
   fgSizer116->Add(m_bExportRoute, 0, wxALL, 5);
 
@@ -634,9 +650,12 @@ WeatherRoutingPanel::WeatherRoutingPanel(wxWindow* parent, wxWindowID id,
   m_bCompute->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                       wxCommandEventHandler(WeatherRoutingPanel::OnCompute),
                       NULL, this);
-  m_bExport->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                     wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsTrack),
-                     NULL, this);
+  m_bSaveAsTrack->Connect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsTrack), NULL, this);
+  m_bSaveAsRoute->Connect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsRoute), NULL, this);
 }
 
 WeatherRoutingPanel::~WeatherRoutingPanel() {
@@ -683,9 +702,12 @@ WeatherRoutingPanel::~WeatherRoutingPanel() {
   m_bCompute->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                          wxCommandEventHandler(WeatherRoutingPanel::OnCompute),
                          NULL, this);
-  m_bExport->Disconnect(
+  m_bSaveAsTrack->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsTrack), NULL, this);
+  m_bSaveAsRoute->Disconnect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(WeatherRoutingPanel::OnSaveAsRoute), NULL, this);
 }
 
 SettingsDialogBase::SettingsDialogBase(wxWindow* parent, wxWindowID id,


### PR DESCRIPTION
This is a partial implementation for #224 

Add menu item and button to save "routing" as route.
This is the basic functionality to add a menu and a button. It is functional and makes it possible to activate the route immediately after saving it.

A follow-up PR is needed and is the harder part: Simplify the route while preserving routing constraints, i.e. minimize the number of waypoints.

**Button:**

<img width="785" alt="image" src="https://github.com/user-attachments/assets/2d08fdf5-e676-47e3-9bfb-20558c53da7a" />

**Menu Item:**

<img width="243" alt="image" src="https://github.com/user-attachments/assets/27498db5-1873-48db-b6d1-92d9b89e900a" />

**Route visible in the "Route and Mark" manager after saving routing.**

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/e89f5ed0-a58f-40aa-a325-3a08bc5ddb63" />
