### PR TITLE
WIP Include "planned speed" when saving routing as route

### DIFF
--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -2787,10 +2787,10 @@ void WeatherRouting::SaveAsRoute(RouteMapOverlay& routemapoverlay) {
   newRoute->m_isVisible = true;
 
   for (auto const& it : plotdata) {
-    PlugIn_Waypoint_Ex* newPoint =
-        new PlugIn_Waypoint_Ex(it.lat, heading_resolve(it.lon), _T("circle"),
-                            _("Weather Route Point"));
-    //newPoint->m_PlannedSpeed = it.sog;
+    PlugIn_Waypoint_ExV2* newPoint =
+        new PlugIn_Waypoint_ExV2(it.lat, heading_resolve(it.lon), _T("circle"),
+                                 _("Weather Route Point"));
+    newPoint->m_PlannedSpeed = it.sog;
     newPoint->m_CreateTime = it.time;
     newRoute->pWaypointList->Append(newPoint);
   }
@@ -2798,7 +2798,7 @@ void WeatherRouting::SaveAsRoute(RouteMapOverlay& routemapoverlay) {
   // last point, missing if config didn't succeed
   Position* p = routemapoverlay.GetDestination();
   if (p) {
-    PlugIn_Waypoint_Ex* newPoint = new PlugIn_Waypoint_Ex(
+    PlugIn_Waypoint_ExV2* newPoint = new PlugIn_Waypoint_ExV2(
         p->lat, p->lon, _T("circle"), _("Weather Route Destination"));
     newPoint->m_CreateTime = routemapoverlay.EndTime();
     newRoute->pWaypointList->Append(newPoint);


### PR DESCRIPTION
# Changes

When the user clicks "Save as route", the weather routing is saved as a route in OpenCPN core. The predicted SOG from the optimal routing in the isochrons is used to set the "planned speed" property in the OpenCPN route.

Previously, the planned speed was set to a constant value (5 knots).

# Tests

I have tested, and we'll need to test again when OpenCPN version 1.12 is released with plugin API version 20. 

- [x] Compute a weather routing and save the routing as a route in OpenCPN.
   - [x] Validate a route has been created.
   - [x] Validate the "planned speed" is saved for each leg and matches the SOG values from what was computed in the weather routing.

In the screenshot below, the "speed" column shows the predicted Speed Over Ground (SOG) for each leg.

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/96592681-b728-4bc1-a78a-3b2682eb9b40" />
