### PR TITLE
Increase max swell resolution

### DIFF
--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -400,7 +400,7 @@ protected:
   wxSpinCtrl* m_sMaxApparentWindKnots;
   wxStaticText* m_staticText1282;
   wxStaticText* m_staticText27;
-  wxSpinCtrl* m_sMaxSwellMeters;
+  wxSpinCtrlDouble* m_sMaxSwellMeters;
   wxStaticText* m_staticText129;
   /** The end point of the route. */
   wxComboBox* m_cEnd;

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -274,7 +274,7 @@ void ConfigurationDialog::SetConfigurations(
   SET_SPIN(MaxTrueWindKnots);
   SET_SPIN(MaxApparentWindKnots);
 
-  SET_SPIN(MaxSwellMeters);
+  SET_SPIN_DOUBLE(MaxSwellMeters);
   SET_SPIN(MaxLatitude);
   SET_SPIN(TackingTime);
   SET_SPIN(JibingTime);

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -1970,7 +1970,7 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure) {
         configuration.MaxApparentWindKnots =
             AttributeDouble(e, "MaxApparentWindKnots", 50);
 
-        configuration.MaxSwellMeters = AttributeDouble(e, "MaxSwellMeters", 20);
+        configuration.MaxSwellMeters = AttributeDouble(e, "MaxSwellMeters", 20.);
         configuration.MaxLatitude = AttributeDouble(e, "MaxLatitude", 90);
         configuration.TackingTime = AttributeDouble(e, "TackingTime", 0);
         configuration.JibingTime = AttributeDouble(e, "JibingTime", 0);
@@ -2104,7 +2104,7 @@ void WeatherRouting::SaveXML(wxString filename) {
     c->SetAttribute("MaxTrueWindKnots", configuration.MaxTrueWindKnots);
     c->SetAttribute("MaxApparentWindKnots", configuration.MaxApparentWindKnots);
 
-    c->SetAttribute("MaxSwellMeters", configuration.MaxSwellMeters);
+    c->SetDoubleAttribute("MaxSwellMeters", configuration.MaxSwellMeters);
     c->SetAttribute("MaxLatitude", configuration.MaxLatitude);
     c->SetAttribute("TackingTime", configuration.TackingTime);
     c->SetAttribute("JibingTime", configuration.JibingTime);
@@ -3206,7 +3206,7 @@ RouteMapConfiguration WeatherRouting::DefaultConfiguration() {
   configuration.MaxTrueWindKnots = 50;      // Safety margin for wind speed
   configuration.MaxApparentWindKnots = 50;  // Safety margin for wind speed
 
-  configuration.MaxSwellMeters = 20;
+  configuration.MaxSwellMeters = 20.;
   configuration.MaxLatitude = 90;
   configuration.TackingTime = 0;
   configuration.JibingTime = 0;

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1316,7 +1316,7 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
 
   m_sMaxSwellMeters = new wxSpinCtrlDouble(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
-      wxSize(140, -1), wxSP_ARROW_KEYS, 0.0 /* min */, 100.0 /* max */, 0.0 /* initial */, 0.1 /* inc */);
+      wxSize(140, -1), wxSP_ARROW_KEYS, 0. /* min */, 100. /* max */, 0. /* initial */, 0.1 /* inc */);
   m_sMaxSwellMeters->SetToolTip(
       _("Maximum swell height to allow during routing.\nRoutes with swell "
         "heights above this value will be avoided."));
@@ -2188,7 +2188,7 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
       wxEVT_MOUSEWHEEL,
       wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_COMMAND_SPINCTRL_UPDATED,
+      wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
   m_cEnd->Connect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                   wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
@@ -2717,7 +2717,7 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
       wxEVT_MOUSEWHEEL,
       wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_COMMAND_SPINCTRL_UPDATED,
+      wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
   m_cEnd->Disconnect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                      wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1316,7 +1316,7 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
 
   m_sMaxSwellMeters = new wxSpinCtrlDouble(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
-      wxSize(-1, -1), wxSP_ARROW_KEYS, 0.0 /* min */, 100.0 /* max */, 0.0 /* initial */, 0.1 /* inc */);
+      wxSize(140, -1), wxSP_ARROW_KEYS, 0.0 /* min */, 100.0 /* max */, 0.0 /* initial */, 0.1 /* inc */);
   m_sMaxSwellMeters->SetToolTip(
       _("Maximum swell height to allow during routing.\nRoutes with swell "
         "heights above this value will be avoided."));

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1314,9 +1314,9 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_staticText27->Wrap(-1);
   fgSizer110->Add(m_staticText27, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  m_sMaxSwellMeters = new wxSpinCtrl(
+  m_sMaxSwellMeters = new wxSpinCtrlDouble(
       sbConstraints->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
-      wxSize(-1, -1), wxSP_ARROW_KEYS, 0, 100, 20);
+      wxSize(-1, -1), wxSP_ARROW_KEYS, 0.0 /* min */, 100.0 /* max */, 0.0 /* initial */, 0.1 /* inc */);
   m_sMaxSwellMeters->SetToolTip(
       _("Maximum swell height to allow during routing.\nRoutes with swell "
         "heights above this value will be avoided."));

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -2131,62 +2131,62 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_LEFT_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_LEFT_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_LEFT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_LEFT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_MIDDLE_DOWN,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_MIDDLE_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_MIDDLE_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_RIGHT_DOWN,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_RIGHT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
       NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_AUX1_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX1_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
-      wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_LEFT_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_MIDDLE_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_RIGHT_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_AUX1_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_AUX2_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_LEAVE_WINDOW,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_ENTER_WINDOW,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_MOUSEWHEEL,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
@@ -2660,62 +2660,62 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_LEFT_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_LEFT_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_LEFT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_LEFT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_MIDDLE_DOWN,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_MIDDLE_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_MIDDLE_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_RIGHT_DOWN,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_RIGHT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_RIGHT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_AUX1_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX1_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
-      wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble),
       NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_LEFT_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_MIDDLE_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_RIGHT_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_AUX1_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_AUX2_DCLICK,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_LEAVE_WINDOW,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_ENTER_WINDOW,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_MOUSEWHEEL,
-      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL, this);
   m_sMaxSwellMeters->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);


### PR DESCRIPTION
Resolves #109 

Fortunately the internal calculations already catered for double values.  Only the user interface component was restricted to integers.  So a fairly easy fix.

Testing:

- [x] Verify value of max swell can be set between 0.0 and 100.0
- [x] Verify value of max swell can have one digit after the decimal point
- [x] Verify value of max swell is compared as a double with GRIB data (e.g. using debugger)
- [x] Verify value of max swell is correct after closing and reloading WR plugin
- [ ] Verify value of max swell is persisted and restored after reloading OpenCPN

cc @rgleason @sebastien-rosset 