### PR TITLE
Add penalty parameter for sail plan change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,8 @@ set(LONG_DESCRIPTION "WR features include: optimal routing subject to various co
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "15")
 set(VERSION_PATCH "21")
-set(VERSION_TWEAK "25")
-set(VERSION_DATE  "11/04/2025")#DD/MM/YYYY format
+set(VERSION_TWEAK "26")
+set(VERSION_DATE  "17/04/2025")#DD/MM/YYYY format
 set(OCPN_MIN_VERSION "ov58")
 
 set(OCPN_API_VERSION_MAJOR "1")

--- a/include/RouteMapOverlay.h
+++ b/include/RouteMapOverlay.h
@@ -124,6 +124,7 @@ public:
     PORT_STARBOARD,     //!< Percentage of time on port tack
     TACKS,              //!< Number of tacks performed
     JIBES,              //!< Number of jibes performed
+    SAIL_PLAN_CHANGES,  //!< Number of sail changes performed
     COMFORT             //!< Sailing comfort level
   };
 

--- a/include/WeatherRouting.h
+++ b/include/WeatherRouting.h
@@ -153,6 +153,8 @@ public:
   wxString Tacks;
   /** Number of jibes performed */
   wxString Jibes;
+  /** Number of sail plan changes performed. */
+  wxString SailPlanChanges;
 
   /** Current computation state of the route. */
   wxString State;
@@ -233,6 +235,7 @@ public:
     PORT_STARBOARD,     //!< Distribution between port and starboard tacks
     TACKS,              //!< Number of tacks performed
     JIBES,              //!< Number of jibes performed
+    SAIL_PLAN_CHANGES,  //!< Number of sail plan changes performed
     COMFORT,            //!< Comfort/safety metrics for conditions
     STATE,              //!< Current computation state of route
     NUM_COLS            //!< Total number of display columns

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -440,9 +440,12 @@ protected:
   wxStaticText* m_staticText24;
   wxSpinCtrl* m_sTackingTime;
   wxStaticText* m_staticText121;
-  wxStaticText* m_staticText25;
+  wxStaticText* m_staticText25;  // Jibing time label
   wxSpinCtrl* m_sJibingTime;
-  wxStaticText* m_staticText122;
+  wxStaticText* m_staticText122;  // "seconds" label for jibing time
+  wxStaticText* m_staticText29;   // Sail plan change time label
+  wxSpinCtrl* m_sSailPlanChangeTime;
+  wxStaticText* m_staticText141;  // "seconds" label for sail plan change time
   wxStaticText* m_staticText241;
   wxSpinCtrlDouble* m_sSafetyMarginLand;
   wxStaticText* m_staticText1211;
@@ -582,6 +585,8 @@ protected:
     TACKS,
     /** Number of jibes in a sailing route. */
     JIBES,
+    /** Number of sail plan changes in a sailing route. */
+    SAIL_PLAN_CHANGES,
   };
 
   /**
@@ -626,6 +631,7 @@ protected:
         {SIG_WAVE_HEIGHT, _("Significant Wave Height")},
         {TACKS, _("Tacks")},
         {JIBES, _("Jibes")},
+        {SAIL_PLAN_CHANGES, _("Sail Plan Changes")},
     };
 
     static const int variableInfoCount =
@@ -943,6 +949,7 @@ protected:
   wxStaticText* m_staticText130;
   wxStaticText* m_staticText126;
   wxStaticText* m_staticText127;
+  wxStaticText* m_staticText129;
   wxStaticText* m_staticText122;
   wxStdDialogButtonSizer* m_sdbSizer5;
   wxButton* m_sdbSizer5OK;
@@ -954,6 +961,7 @@ public:
   wxStaticText* m_stSailChanges;
   wxStaticText* m_stTacks;
   wxStaticText* m_stJibes;
+  wxStaticText* m_stSailPlanChanges;
   wxStaticText* m_stWeatherData;
 
   CursorPositionDialog(wxWindow* parent, wxWindowID id = wxID_ANY,
@@ -1005,6 +1013,7 @@ public:
   wxStaticText* m_stSailChanges;
   wxStaticText* m_stTacks;
   wxStaticText* m_stJibes;
+  wxStaticText* m_stSailPlanChanges;
   wxStaticText* m_stWeatherData;
 
   RoutePositionDialog(wxWindow* parent, wxWindowID id = wxID_ANY,

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -278,6 +278,7 @@ void ConfigurationDialog::SetConfigurations(
   SET_SPIN(MaxLatitude);
   SET_SPIN(TackingTime);
   SET_SPIN(JibingTime);
+  SET_SPIN(SailPlanChangeTime);
   SET_SPIN(WindVSCurrent);
 
   SET_CHECKBOX(AvoidCycloneTracks);
@@ -353,6 +354,7 @@ void ConfigurationDialog::OnResetAdvanced(wxCommandEvent& event) {
   m_sNightCumulativeEfficiency->SetValue(100);
   m_sTackingTime->SetValue(0);
   m_sJibingTime->SetValue(0);
+  m_sSailPlanChangeTime->SetValue(0);
   m_sSafetyMarginLand->SetValue(0.);
 
   m_sFromDegree->SetValue(0);
@@ -509,6 +511,7 @@ void ConfigurationDialog::Update() {
     GET_SPIN(MaxLatitude);
     GET_SPIN(TackingTime);
     GET_SPIN(JibingTime);
+    GET_SPIN(SailPlanChangeTime);
     GET_SPIN(WindVSCurrent);
 
     if (m_sWindStrength->IsEnabled())

--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -135,6 +135,8 @@ double PlotDialog::GetValue(PlotData& data, Variable variable) {
       return data.tacks;
     case JIBES:
       return data.jibes;
+    case SAIL_PLAN_CHANGES:
+      return data.sail_plan_changes;
   }
   return NAN;
 }

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -422,10 +422,11 @@ static inline int TestIntersectionXY(double x1, double y1, double x2, double y2,
 #define EPSILON (2e-11)
 
 Position::Position(double latitude, double longitude, Position* p,
-                   double pheading, double pbearing, int polar_, int tacks_,
-                   int jibes_, int data_mask_, bool data_deficient_)
-    : RoutePoint(latitude, longitude, polar_, tacks_, jibes_, data_mask_,
-                 data_deficient_),
+                   double pheading, double pbearing, int polar_idx,
+                   int tack_count, int jibe_count, int sail_plan_change_count,
+                   int data_mask, bool data_deficient)
+    : RoutePoint(latitude, longitude, polar_idx, tack_count, jibe_count,
+                 sail_plan_change_count, data_mask, data_deficient),
       parent_heading(pheading),
       parent_bearing(pbearing),
       parent(p),
@@ -438,7 +439,7 @@ Position::Position(double latitude, double longitude, Position* p,
 
 Position::Position(Position* p)
     : RoutePoint(p->lat, p->lon, p->polar, p->tacks, p->jibes,
-                 p->grib_is_data_deficient, p->data_mask),
+                 p->sail_plan_changes, p->grib_is_data_deficient, p->data_mask),
       parent_heading(p->parent_heading),
       parent_bearing(p->parent_bearing),
       parent(p->parent),
@@ -1002,6 +1003,7 @@ bool Position::Propagate(IsoRouteList& routelist,
       int newpolar = configuration.boat.FindBestPolarForCondition(
           polar, twsOverWater, twa, swell, configuration.OptimizeTacking,
           &status);
+      bool sail_plan_changed = false;
       bool inside_polar_bounds = true;
       if (newpolar == -1 || status != PolarSpeedStatus::POLAR_SPEED_SUCCESS) {
         if (newpolar == -1 && polar >= 0) {
@@ -1023,6 +1025,11 @@ bool Position::Propagate(IsoRouteList& routelist,
           configuration.polar_status = status;
           continue;
         }
+      }
+      if (polar > 0 && newpolar != polar) {
+        // Apply penalty for changing sail plan.
+        timeseconds -= configuration.SailPlanChangeTime;
+        sail_plan_changed = true;
       }
 
       /* did we tack thru the wind? apply penalty */
@@ -1232,8 +1239,8 @@ bool Position::Propagate(IsoRouteList& routelist,
       }
 
       rp = new Position(dlat, dlon, this, twa, ctw, newpolar, tacks + tacked,
-                        jibes + jibed, data_mask,
-                        configuration.grib_is_data_deficient);
+                        jibes + jibed, sail_plan_changes + sail_plan_changed,
+                        data_mask, configuration.grib_is_data_deficient);
     }
   add_position:
     if (points) {
@@ -2704,9 +2711,11 @@ bool IsoRoute::Propagate(IsoRouteList& routelist,
 void IsoRoute::PropagateToEnd(RouteMapConfiguration& configuration,
                               double& mindt, Position*& endp, double& minH,
                               bool& mintacked, bool& minjibed,
-                              int& mindata_mask) {
+                              bool& minsail_plan_changed, int& mindata_mask) {
   Position* p = skippoints->point;
-
+  // TODO: it does not look like this function is used anywhere.
+  // If it is used, one problem is that it does not check for the
+  // case when there is a sailplan change.
   do {
     double H;
     int data_mask = 0;
@@ -2745,7 +2754,7 @@ void IsoRoute::PropagateToEnd(RouteMapConfiguration& configuration,
   for (IsoRouteList::iterator cit = children.begin(); cit != children.end();
        cit++)
     (*cit)->PropagateToEnd(configuration, mindt, endp, minH, mintacked,
-                           minjibed, mindata_mask);
+                           minjibed, minsail_plan_changed, mindata_mask);
 }
 
 int IsoRoute::SkipCount() {

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -195,7 +195,7 @@ void RouteMapOverlay::RouteAnalysis(PlugIn_Route* proute) {
   last_destination_position = new Position(
       data.lat, data.lon, nullptr /* position */, NAN /* heading */,
       NAN /* bearing*/, data.polar, 0 /* tacks */, 0 /* jibes */,
-      0 /* data_mask */, true /* data_deficient */);
+      0 /* sailplan changes */, 0 /* data_mask */, true /* data_deficient */);
 
   last_cursor_plotdata = last_destination_plotdata;
   if (ok) {
@@ -1649,6 +1649,7 @@ void RouteMapOverlay::UpdateDestination() {
     double minH;
     bool mintacked;
     bool minjibes;
+    bool minsail_plan_changed;
     int mindata_mask;
 
     for (IsoRouteList::iterator it = isochron->routes.begin();
@@ -1659,7 +1660,7 @@ void RouteMapOverlay::UpdateDestination() {
       configuration.time = isochron->time;
       configuration.UsedDeltaTime = isochron->delta;
       (*it)->PropagateToEnd(configuration, mindt, endp, minH, mintacked,
-                            minjibes, mindata_mask);
+                            minjibes, minsail_plan_changed, mindata_mask);
     }
     Unlock();
 
@@ -1672,10 +1673,10 @@ void RouteMapOverlay::UpdateDestination() {
       last_destination_position =
           ClosestPosition(configuration.EndLat, configuration.EndLon);
     } else {
-      destination_position =
-          new Position(configuration.EndLat, configuration.EndLon, endp, minH,
-                       NAN, endp->polar, endp->tacks + mintacked,
-                       endp->jibes + minjibes, mindata_mask);
+      destination_position = new Position(
+          configuration.EndLat, configuration.EndLon, endp, minH, NAN,
+          endp->polar, endp->tacks + mintacked, endp->jibes + minjibes,
+          endp->sail_plan_changes + minsail_plan_changed, mindata_mask);
 
       m_EndTime = isochron->time + wxTimeSpan::Milliseconds(1000 * mindt);
       isochron->delta = mindt;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -61,6 +61,7 @@ const wxString SettingsDialog::column_names[] = {"",  // "Visible" column
                                                  "Port Starboard",
                                                  "Tacks",
                                                  "Jibes",
+                                                 "Sail Plan Changes",
                                                  "Sailing Comfort",
                                                  "State"};
 

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1825,6 +1825,39 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
 
   // End Jibing time.
 
+  // Begin Sail Plan Change time.
+
+  wxFlexGridSizer* fgSizer1153;
+  fgSizer1153 = new wxFlexGridSizer(1, 0, 0, 0);
+  fgSizer1153->SetFlexibleDirection(wxBOTH);
+  fgSizer1153->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+  m_staticText29 = new wxStaticText(sbOptions1->GetStaticBox(), wxID_ANY,
+                                    _("Sail Plan Change Time"),
+                                    wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText29->Wrap(-1);
+  fgSizer1153->Add(m_staticText29, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+  m_sSailPlanChangeTime = new wxSpinCtrl(
+      sbOptions1->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition,
+      wxSize(140, -1), wxSP_ARROW_KEYS, 0, 1000, 1);
+  m_sSailPlanChangeTime->SetToolTip(
+      _("Set the time in seconds needed to complete a sail plan change. Higher "
+        "values create more realistic routing that accounts for the speed loss "
+        "during change of sail plan. This affects planning by making frequent "
+        "sail changes less advantageous."));
+  fgSizer1153->Add(m_sSailPlanChangeTime, 0, wxALL | wxALIGN_CENTER_VERTICAL,
+                   5);
+  m_staticText141 =
+      new wxStaticText(sbOptions1->GetStaticBox(), wxID_ANY, _("Seconds"),
+                       wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText141->Wrap(-1);
+  fgSizer1153->Add(m_staticText141, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+  fgSizer113->Add(fgSizer1153, 1, wxEXPAND, 5);
+
+  // End Sail Plan Change time.
+
   wxFlexGridSizer* fgSizer11511;
   fgSizer11511 = new wxFlexGridSizer(1, 0, 0, 0);
   fgSizer11511->SetFlexibleDirection(wxBOTH);
@@ -2481,9 +2514,6 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
       wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
       NULL, this);
   m_sJibingTime->Connect(
-      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
-      NULL, this);
-  m_sJibingTime->Connect(
       wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
       NULL, this);
   m_sJibingTime->Connect(
@@ -2513,6 +2543,66 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sJibingTime->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+
+  //
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_LEFT_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_LEFT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_MIDDLE_DOWN,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_MIDDLE_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_RIGHT_DOWN,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_RIGHT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_AUX1_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_LEFT_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_MIDDLE_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_RIGHT_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_AUX1_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_AUX2_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_LEAVE_WINDOW,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_ENTER_WINDOW,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_MOUSEWHEEL,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Connect(
+      wxEVT_COMMAND_SPINCTRL_UPDATED,
+      wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+
   m_sSafetyMarginLand->Connect(
       wxEVT_MOTION,
       wxMouseEventHandler(ConfigurationDialogBase::EnableSpinDouble), NULL,
@@ -3043,6 +3133,68 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
   m_sJibingTime->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+  //
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_LEFT_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_LEFT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_MIDDLE_DOWN,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_MIDDLE_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_RIGHT_DOWN,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_RIGHT_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_AUX1_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_AUX2_DOWN, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_AUX1_UP, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
+      NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_LEFT_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_MIDDLE_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_RIGHT_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_AUX1_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_AUX2_DCLICK,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_LEAVE_WINDOW,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_ENTER_WINDOW,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_MOUSEWHEEL,
+      wxMouseEventHandler(ConfigurationDialogBase::EnableSpin), NULL, this);
+  m_sSailPlanChangeTime->Disconnect(
+      wxEVT_COMMAND_SPINCTRL_UPDATED,
+      wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+  //
   m_sSafetyMarginLand->Disconnect(
       wxEVT_MOTION, wxMouseEventHandler(ConfigurationDialogBase::EnableSpin),
       NULL, this);
@@ -4972,7 +5124,7 @@ CursorPositionDialog::CursorPositionDialog(wxWindow* parent, wxWindowID id,
   m_stTacks->Wrap(-1);
   fgSizer91->Add(m_stTacks, 0, wxALL | wxEXPAND, 5);
 
-  //
+  // Jibes
   m_staticText127 = new wxStaticText(this, wxID_ANY, _("Jibes"),
                                      wxDefaultPosition, wxDefaultSize, 0);
   m_staticText127->Wrap(-1);
@@ -4982,6 +5134,18 @@ CursorPositionDialog::CursorPositionDialog(wxWindow* parent, wxWindowID id,
                                wxDefaultSize, 0);
   m_stJibes->Wrap(-1);
   fgSizer91->Add(m_stJibes, 0, wxALL | wxEXPAND, 5);
+
+  // Sail Plan Changes
+  m_staticText129 = new wxStaticText(this, wxID_ANY, _("Sail Plan Changes"),
+                                     wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText129->Wrap(-1);
+  fgSizer91->Add(m_staticText129, 0, wxALL, 5);
+
+  m_stSailPlanChanges = new wxStaticText(this, wxID_ANY, wxEmptyString,
+                                         wxDefaultPosition, wxDefaultSize, 0);
+  m_stSailPlanChanges->Wrap(-1);
+  fgSizer91->Add(m_stSailPlanChanges, 0, wxALL | wxEXPAND, 5);
+  //
 
   m_staticText122 = new wxStaticText(this, wxID_ANY, _("Weather Data"),
                                      wxDefaultPosition, wxDefaultSize, 0);


### PR DESCRIPTION
# Overview

Add a "Sail Plan Change Time" parameter to specify a penalty when changing sail plan. This is useful when a boat configuration has multiple polars. This takes into consideration the time it takes to change sail plan and can be used to reduce the total number of sail plan changes.

This parameter has no impact if the boat configuration has a single sail plan.

# Tests

- [x] Validate the "Sail Plan Change Time" parameter is displayed in routing "Advanced settings".
- [x] Validate the "Sail Plan Change Time" has a tooltip.
- [x] Validate the value of the "Sail Plan Change Time" parameter is persisted and restored when OpenCPN is closed and restarted.
- [x] Validate the route planning takes the sail plan penalty into consideration. This requires a) creating a boat configuration that has more than one polar. b) creating a route that will cause multiple sail plan changes (e.g. headsail vs assymmetric vers symmetric spinnaker). c) computing the route with "Sail Plan Change Time" and checking there are multiple sail plan changes. d) Increasing the value of "Sail Plan Change Time" and re-computing the route, check the number of sail plan changes has been reduced.
- [x] Validate in "Weather Routing Settings", the user can select/unselect the "Sail Plan Changes" column.
- [x] Validate in "Weather Route Report", the number of "Sail Plan Changes" is displayed.
- [x] Validate in "Cursor Position", the number of "Sail Plan Changes" is displayed.
- [x] Validate in "Route Position", the number of "Sail Plan Changes" is displayed.
- [x] Validate in "Route Plots", the number of "Sail Plan Changes" is selectable as a variable.

# Example

Create a boat configuration that has multiple polars:
1. Headsail
2. Asymmetric spinnaker
3. Symmetric spinnaker

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/8510ba1b-8e55-4f3e-b95d-18e3979f24c7" />

When creating a route, the navigator may want to control how much time it takes to change the sail plan. A penalty is applied when the sail plan is changed, which tends to reduce the number of sail plan changes.