### PR TITLE
Persist Safety Margin from Land correctly as a double

### DIFF
--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -2134,7 +2134,7 @@ void WeatherRouting::SaveXML(wxString filename) {
                           configuration.NightCumulativeEfficiency);
 
     c->SetAttribute("DetectLand", configuration.DetectLand);
-    c->SetAttribute("SafetyMarginLand", configuration.SafetyMarginLand);
+    c->SetDoubleAttribute("SafetyMarginLand", configuration.SafetyMarginLand);
     c->SetAttribute("DetectBoundary", configuration.DetectBoundary);
     c->SetAttribute("Currents", configuration.Currents);
     c->SetAttribute("OptimizeTacking", configuration.OptimizeTacking);


### PR DESCRIPTION
While implementing #289 I noticed a bug causing Safety Margin from Land to be truncated to an int when being persisted. 

Before this fix, that configuration setting got chopped to an int.  After this fix, the decimal place gets saved and loaded correctly.

@rgleason @sebastien-rosset FYI