### PR TITLE
Positions reformatted on the fly on format preference change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ if (NOT OCPN_FLATPAK_CONFIG)
     target_link_libraries(${PACKAGE_NAME} windows::headers)
   endif (WIN32)
 
-  add_subdirectory(opencpn-libs/api-18)
+  add_subdirectory(opencpn-libs/api-${OCPN_API_VERSION_MINOR})
   target_link_libraries(${PACKAGE_NAME} ocpn::api)
 
   add_subdirectory(opencpn-libs/tinyxml)

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -40,6 +40,7 @@
 #include "AboutDialog.h"
 #include "icons.h"
 #include "navobj_util.h"
+#include "ocpn_plugin.h"
 
 /**
  * Used for NEflag argument to toSDMM_Plugin function from ocpn_plugin.h.

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -563,46 +563,70 @@ void WeatherRouting::CopyDataFiles(wxString from, wxString to) {
 }
 
 void WeatherRouting::Render(piDC& dc, PlugIn_ViewPort& vp) {
+  static int prevLocationFormat = -1; // Last time we rendered, which SDMM format was used
+  int currentLocationFormat; // To determine whether preferred SDMM format has changed.
+  bool locationFormatChanged = false;
+
   if (vp.bValid == false) return;
 
-  // polling is bad
-  bool work = false;
-  for (auto& it : RouteMap::Positions) {
-    if (it.GUID.IsEmpty()) continue;
+  currentLocationFormat = GetLatLonFormat();
+  if(currentLocationFormat != prevLocationFormat) {
+    prevLocationFormat = currentLocationFormat;
+    locationFormatChanged = true;
+  }
 
+  // polling is bad
+  bool work = false;  // Have any of the positions changed since we last rendered?
+  for (auto& it : RouteMap::Positions) {
     PlugIn_Waypoint waypoint;
+    bool gotWaypoint = false;
+    wxString name = it.Name;
     double lat = it.lat;
     double lon = it.lon;
-
-    if (!GetSingleWaypoint(it.GUID, &waypoint)) continue;
-    if (lat == waypoint.m_lat && lon == waypoint.m_lon &&
-        waypoint.m_MarkName.IsSameAs(it.Name))
-      continue;
-
+    if (!(it.GUID.IsEmpty())) {
+      gotWaypoint = GetSingleWaypoint(it.GUID, &waypoint);
+      if (gotWaypoint) {
+        if (lat == waypoint.m_lat && lon == waypoint.m_lon &&
+          waypoint.m_MarkName.IsSameAs(it.Name)) {
+            ; // nothing has changed; nothing to do
+        } else {
+          work = true;
+        }
+      }  
+    } 
+  
     long index = m_panel->m_lPositions->FindItem(0, it.ID);
     if (index < 0) {
       // corrupted data
       continue;
     }
 
-    wxString name = waypoint.m_MarkName;
-    lat = waypoint.m_lat;
-    lon = waypoint.m_lon;
-    it.Name = name;
-    it.lat = lat;
-    it.lon = lon;
+    if (gotWaypoint && work) {
+      name = waypoint.m_MarkName;
+      lat = waypoint.m_lat;
+      lon = waypoint.m_lon;
+      it.Name = name;
+      it.lat = lat;
+      it.lon = lon;
+    }
 
     // XXX FIXME there's already this name, update m_ConfigurationDialog source
-    m_panel->m_lPositions->SetItem(index, POSITION_NAME, name);
-    m_panel->m_lPositions->SetColumnWidth(POSITION_NAME, wxLIST_AUTOSIZE);
-    m_panel->m_lPositions->SetItem(
-        index, POSITION_LAT, toSDMM_PlugIn(NEflag::LAT, lat, Precision::HI));
-    m_panel->m_lPositions->SetColumnWidth(POSITION_LAT, wxLIST_AUTOSIZE);
-    m_panel->m_lPositions->SetItem(
-        index, POSITION_LON, toSDMM_PlugIn(NEflag::LON, lon, Precision::HI));
-    m_panel->m_lPositions->SetColumnWidth(POSITION_LON, wxLIST_AUTOSIZE);
-    work = true;
+    if (work || locationFormatChanged) {
+      m_panel->m_lPositions->SetItem(index, POSITION_NAME, name);
+      m_panel->m_lPositions->SetColumnWidth(POSITION_NAME, wxLIST_AUTOSIZE);
+      m_panel->m_lPositions->SetItem(index, POSITION_LAT,
+                                     toSDMM_PlugIn(NEflag::LAT, lat, Precision::HI));
+      m_panel->m_lPositions->SetColumnWidth(POSITION_LAT, wxLIST_AUTOSIZE);
+      m_panel->m_lPositions->SetItem(index, POSITION_LON,
+                                     toSDMM_PlugIn(NEflag::LON, lon, Precision::HI));
+      m_panel->m_lPositions->SetColumnWidth(POSITION_LON, wxLIST_AUTOSIZE);
+    }
   }
+
+  if (work || locationFormatChanged) {
+    GetParent()->Refresh();
+  }
+  
   if (work) {
     UpdateConfigurations();
     Reset();

--- a/src/georef.cpp
+++ b/src/georef.cpp
@@ -39,6 +39,7 @@
 #include <wx/debug.h>
 
 #include "georef.h"
+#include "cutil.h"
 
 #ifdef __MSVC__
 #define snprintf mysnprintf


### PR DESCRIPTION
This is one of the two clean-up items from #285.

Location co-ordinates were not automatically reformatted when global format preferences changed. This was due to some code that suppressed rerendering unless the actual name or latlong had changed.  By restructuring that code, and correctly rerendering if the format preference changed, regardless of whether the actual location changed, this has been resolved. 

@sebastien-rosset Please take a close look at the code, because the logic changed in a slightly non-trivial way to accommodate this improvement. I tried to disrupt the existing code as minimally as possible, deferring any rewrite to some later refactoring/cleanup.

Testing:
[] Switch to global Options/Display/LatLong, change preference. Switch back to Weather Routing and verify that locations list is rerendered to the correct format. 
[] As above, for Cursor Position dialog.
[] As above, for Routing Position dialog.
[] Create and compute a weather routing, to confirm that that has not somehow been screwed up by the changes.

<img width="425" alt="Screenshot 2025-04-28 at 14 59 32" src="https://github.com/user-attachments/assets/1f1536be-5849-47ef-8b3d-15c51817d4c8" />
<img width="1413" alt="Screenshot 2025-04-28 at 14 52 46" src="https://github.com/user-attachments/assets/e25dd67b-3ac4-40cd-8d43-e759131f93fe" />
<img width="1415" alt="Screenshot 2025-04-28 at 14 51 58" src="https://github.com/user-attachments/assets/9e5d4c4a-0fda-49c9-905b-4548a472fce0" />

@sebastien-rosset @rgleason FYI