### PR TITLE
Color code time of day in weather routing table

### DIFF
--- a/include/RoutingTablePanel.h
+++ b/include/RoutingTablePanel.h
@@ -94,6 +94,22 @@ private:
   void setCellWithColor(int row, int col, const wxString& value,
                         const wxColor& bgColor);
 
+  /**
+   * Helper function to set cell value with time-of-day background color.
+   * This method uses the SunCalculator to determine appropriate colors based on
+   * the time of day and daylight status at the given location.
+   *
+   * @param row Grid row number
+   * @param col Grid column number
+   * @param value Text value to display in the cell
+   * @param dateTime UTC time for this route point
+   * @param lat Latitude of the route point
+   * @param lon Longitude of the route point
+   */
+  void setCellWithTimeOfDayColor(int row, int col, const wxString& value,
+                                 const wxDateTime& dateTime, double lat,
+                                 double lon);
+
   enum WeatherDataColumn {
     COL_LEG_NUMBER,  //!< Leg number
     COL_ETA,  //!< Estimated Time of Arrival - actual date/time of this point

--- a/include/SunCalculator.h
+++ b/include/SunCalculator.h
@@ -57,12 +57,17 @@ public:
    * times
    * @param sunrise [out] Returns the sunrise time in UTC for the specified date
    * @param sunset [out] Returns the sunset time in UTC for the specified date
+   * @param dateTime Optional UTC date and time for sun elevation calculation
+   * @param sunElevation Optional output parameter for sun elevation angle in
+   * degrees
    */
   static void CalculateSun(double latit, double longit, int dayOfYear,
-                           wxDateTime& sunrise, wxDateTime& sunset);
+                           wxDateTime& sunrise, wxDateTime& sunset,
+                           const wxDateTime* dateTime = nullptr,
+                           double* sunElevation = nullptr);
 
   /**
-   * Determines whether it's day or night at a specific location and time
+   * Determines whether it's day or night at a specific location and time.
    *
    * This function checks if a given time at a particular location is during
    * daylight or nighttime by calculating the sunrise and sunset times. It uses
@@ -77,11 +82,14 @@ public:
    * @param lon Longitude in decimal degrees (positive for East, negative for
    * West)
    * @param time UTC time for which to determine day/night status
+   * @param sunElevation Optional output parameter for sun elevation angle in
+   * degrees (positive above horizon, negative below horizon)
    * @return DayTime enum value (Day or Night) indicating whether it's daytime
    * or nighttime
    */
   DayLightStatus GetDayLightStatus(double lat, double lon,
-                                   const wxDateTime& time);
+                                   const wxDateTime& time,
+                                   double* sunElevation = nullptr);
 
 private:
   SunCalculator() {

--- a/src/RoutingTablePanel.cpp
+++ b/src/RoutingTablePanel.cpp
@@ -26,6 +26,7 @@
 #include "RouteMapOverlay.h"
 #include "WeatherRouting.h"
 #include "RoutingTablePanel.h"
+#include "SunCalculator.h"
 
 BEGIN_EVENT_TABLE(RoutingTablePanel, wxPanel)
 EVT_SIZE(RoutingTablePanel::OnSize)
@@ -481,6 +482,51 @@ static wxColor GetCurrentEffectColor(double currentAngle, double currentSpeed) {
   }
 }
 
+// Helper function to get time-of-day color based on sun elevation angle
+// Color scheme follows nautical standards for visibility and navigation
+// conditions:
+// - High sun (>15°): Bright yellow - excellent visibility
+// - Civil twilight (0° to 6°): Light colors - good navigation conditions
+// - Nautical twilight (-6° to 0°): Moderate colors - horizon visible
+// - Astronomical twilight (-12° to -6°): Darker colors - star navigation
+// - Deep night (<-18°): Dark blue - full night conditions
+static wxColor GetTimeOfDayColor(const wxDateTime& dateTime, double lat,
+                                 double lon) {
+  // Use the enhanced CalculateSun function with precise sun elevation
+  // calculation
+  wxDateTime sunrise, sunset;
+  double sunElevation;
+  SunCalculator::CalculateSun(lat, lon, dateTime.GetDayOfYear(), sunrise,
+                              sunset, &dateTime, &sunElevation);
+
+  // Define color transitions based on sun elevation angles (following nautical
+  // standards)
+  if (sunElevation > 15.0) {
+    // High sun - excellent visibility for coral reefs, navigation, harbor entry
+    return wxColor(255, 255, 180);  // Bright yellow - high visibility
+  } else if (sunElevation > 6.0) {
+    // Civil twilight begins - sun visible, good general navigation
+    return wxColor(255, 248, 220);  // Light cream - good visibility
+  } else if (sunElevation > 0.0) {
+    // Civil twilight - some natural light, horizon clearly visible
+    return wxColor(255, 228, 181);  // Soft peach - moderate visibility
+  } else if (sunElevation > -6.0) {
+    // Nautical twilight - horizon no longer visible, but navigation still
+    // possible
+    return wxColor(205, 181, 205);  // Light lavender - twilight navigation
+  } else if (sunElevation > -12.0) {
+    // Astronomical twilight - quite dark, celestial navigation
+    return wxColor(147, 112, 147);  // Medium purple - star navigation
+  } else if (sunElevation > -18.0) {
+    // End of astronomical twilight - very dark but some astronomical objects
+    // visible
+    return wxColor(72, 61, 139);  // Dark slate blue - deep twilight
+  } else {
+    // Complete night - sun more than 18 degrees below horizon
+    return wxColor(25, 25, 112);  // Midnight blue - full night
+  }
+}
+
 RoutingTablePanel::RoutingTablePanel(wxWindow* parent,
                                      WeatherRouting& weatherRouting,
                                      RouteMapOverlay* routemap)
@@ -603,6 +649,15 @@ void RoutingTablePanel::setCellWithColor(int row, int col,
   m_gridWeatherTable->SetAttr(row, col, attr);
 }
 
+// Helper function to set cell value with time-of-day background color
+void RoutingTablePanel::setCellWithTimeOfDayColor(int row, int col,
+                                                  const wxString& value,
+                                                  const wxDateTime& dateTime,
+                                                  double lat, double lon) {
+  wxColor timeColor = GetTimeOfDayColor(dateTime, lat, lon);
+  setCellWithColor(row, col, value, timeColor);
+}
+
 // Helper function to format and display sail plan information
 void RoutingTablePanel::handleSailPlanCell(
     int row, const PlotData& data, const RouteMapConfiguration& configuration,
@@ -657,9 +712,10 @@ void RoutingTablePanel::PopulateTable() {
   double cumulativeDistance = 0.0;  // Track total distance
 
   for (const PlotData& data : plotData) {
-    // Populate the leg number column
-    m_gridWeatherTable->SetCellValue(row, COL_LEG_NUMBER,
-                                     wxString::Format("%d", row + 1));
+    // Populate the leg number column with time-of-day background color
+    setCellWithTimeOfDayColor(row, COL_LEG_NUMBER,
+                              wxString::Format("%d", row + 1), data.time,
+                              data.lat, data.lon);
 
     // ETA column - actual date/time of arrival at this point
     // Check for API 1.20 which has toUsrDateTimeFormat_Plugin function
@@ -668,15 +724,28 @@ void RoutingTablePanel::PopulateTable() {
     (OCPN_API_VERSION_MAJOR == 1 && OCPN_API_VERSION_MINOR >= 20)
     timeString = toUsrDateTimeFormat_Plugin(data.time);
 #else
-    // Fallback for earlier API versions - format time in UTC
-    timeString = data.time.Format(_T("%Y-%m-%d %H:%M UTC"));
+    // Fallback for earlier API versions - format time with proper timezone
+    // label
+    wxDateTime displayTime = data.time;
+    if (useLocalTime) {
+      displayTime = data.time.FromUTC();
+    }
+    if (useLocalTime) {
+      timeString = displayTime.Format(_T("%Y-%m-%d %H:%M %Z"));
+    } else {
+      timeString = displayTime.Format(_T("%Y-%m-%d %H:%M UTC"));
+    }
 #endif
-    m_gridWeatherTable->SetCellValue(row, COL_ETA, timeString);
+    // ETA column with time-of-day background color
+    setCellWithTimeOfDayColor(row, COL_ETA, timeString, data.time, data.lat,
+                              data.lon);
 
     // Store the first point's time to calculate total time from start
     if (firstPoint) {
       startTime = data.time;
-      m_gridWeatherTable->SetCellValue(row, COL_ENROUTE, _("Start"));
+      // Total Time column with time-of-day background color
+      setCellWithTimeOfDayColor(row, COL_ENROUTE, _("Start"), data.time,
+                                data.lat, data.lon);
       m_gridWeatherTable->SetCellValue(row, COL_LEG_DISTANCE, _("0.0"));
       firstPoint = false;
     } else {
@@ -700,8 +769,10 @@ void RoutingTablePanel::PopulateTable() {
                              totalDuration.GetMinutes() % 60);
       }
 
-      // Set the cumulative duration in EnRoute column
-      m_gridWeatherTable->SetCellValue(row, COL_ENROUTE, totalDurationString);
+      // Set the cumulative duration in EnRoute column with time-of-day
+      // background color
+      setCellWithTimeOfDayColor(row, COL_ENROUTE, totalDurationString,
+                                data.time, data.lat, data.lon);
 
       // Set the cumulative distance in Distance column using unit conversion
       m_gridWeatherTable->SetCellValue(row, COL_LEG_DISTANCE,

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -565,20 +565,23 @@ void WeatherRouting::CopyDataFiles(wxString from, wxString to) {
 }
 
 void WeatherRouting::Render(piDC& dc, PlugIn_ViewPort& vp) {
-  static int prevLocationFormat = -1; // Last time we rendered, which SDMM format was used
-  int currentLocationFormat; // To determine whether preferred SDMM format has changed.
+  static int prevLocationFormat =
+      -1;  // Last time we rendered, which SDMM format was used
+  int currentLocationFormat;  // To determine whether preferred SDMM format has
+                              // changed.
   bool locationFormatChanged = false;
 
   if (vp.bValid == false) return;
 
   currentLocationFormat = GetLatLonFormat();
-  if(currentLocationFormat != prevLocationFormat) {
+  if (currentLocationFormat != prevLocationFormat) {
     prevLocationFormat = currentLocationFormat;
     locationFormatChanged = true;
   }
 
   // polling is bad
-  bool work = false;  // Have any of the positions changed since we last rendered?
+  // Have any of the positions changed since we last rendered?
+  bool work = false;
   for (auto& it : RouteMap::Positions) {
     PlugIn_Waypoint waypoint;
     bool gotWaypoint = false;
@@ -589,14 +592,14 @@ void WeatherRouting::Render(piDC& dc, PlugIn_ViewPort& vp) {
       gotWaypoint = GetSingleWaypoint(it.GUID, &waypoint);
       if (gotWaypoint) {
         if (lat == waypoint.m_lat && lon == waypoint.m_lon &&
-          waypoint.m_MarkName.IsSameAs(it.Name)) {
-            ; // nothing has changed; nothing to do
+            waypoint.m_MarkName.IsSameAs(it.Name)) {
+          ;  // nothing has changed; nothing to do
         } else {
           work = true;
         }
-      }  
-    } 
-  
+      }
+    }
+
     long index = m_panel->m_lPositions->FindItem(0, it.ID);
     if (index < 0) {
       // corrupted data
@@ -616,11 +619,11 @@ void WeatherRouting::Render(piDC& dc, PlugIn_ViewPort& vp) {
     if (work || locationFormatChanged) {
       m_panel->m_lPositions->SetItem(index, POSITION_NAME, name);
       m_panel->m_lPositions->SetColumnWidth(POSITION_NAME, wxLIST_AUTOSIZE);
-      m_panel->m_lPositions->SetItem(index, POSITION_LAT,
-                                     toSDMM_PlugIn(NEflag::LAT, lat, Precision::HI));
+      m_panel->m_lPositions->SetItem(
+          index, POSITION_LAT, toSDMM_PlugIn(NEflag::LAT, lat, Precision::HI));
       m_panel->m_lPositions->SetColumnWidth(POSITION_LAT, wxLIST_AUTOSIZE);
-      m_panel->m_lPositions->SetItem(index, POSITION_LON,
-                                     toSDMM_PlugIn(NEflag::LON, lon, Precision::HI));
+      m_panel->m_lPositions->SetItem(
+          index, POSITION_LON, toSDMM_PlugIn(NEflag::LON, lon, Precision::HI));
       m_panel->m_lPositions->SetColumnWidth(POSITION_LON, wxLIST_AUTOSIZE);
     }
   }
@@ -628,7 +631,7 @@ void WeatherRouting::Render(piDC& dc, PlugIn_ViewPort& vp) {
   if (work || locationFormatChanged) {
     GetParent()->Refresh();
   }
-  
+
   if (work) {
     UpdateConfigurations();
     Reset();


### PR DESCRIPTION
Add background color to show time of day  (daylight, dusk/dawn, night). This makes it easier to interpret weather tables.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/501967b5-1ec2-43cf-9324-f3e8c947d84f" />

Enhanced color map based on discussion with @quinton-hoole:

<img width="1401" alt="image" src="https://github.com/user-attachments/assets/8f4a0403-44a0-4c05-aa6e-4cad4b58a2b4" />

