### PR TITLE
Enhance polar diagram visualization

### DIFF
--- a/include/BoatDialog.h
+++ b/include/BoatDialog.h
@@ -154,6 +154,8 @@ private:
 
   void RepopulatePolars();
 
+  void UpdateCursorInfo();
+
   void RefreshPlots() {
     m_PlotWindow->Refresh();
     m_CrossOverChart->Refresh();
@@ -170,6 +172,19 @@ private:
 
   double m_PlotScale;
   int m_MouseW;
+
+  // Interactive hover state
+  int m_HoveredWindSpeedIndex;
+  bool m_ShowHoverInfo;
+
+  // Cursor tracking for information display
+  wxPoint m_CursorPosition;
+  bool m_CursorValid;
+  double m_CursorWindAngle;
+  double m_CursorWindSpeed;
+  double m_CursorBoatSpeed;
+  double m_CursorVMG;
+  double m_CursorVMGAngle;  // Optimal VMG angle at cursor position
 
   bool m_CrossOverRegenerate;
   CrossOverGenerationThread* m_CrossOverGenerationThread;

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -84,9 +84,9 @@ double deg2rad(double degrees);
 double rad2deg(double radians);
 
 /**
- * Normalize heading angle to range [-180, 180]
+ * Normalize heading angle to range [-180, 180)
  * @param degrees Angle in degrees (any range)
- * @return Normalized angle in range [-180, 180]
+ * @return Normalized angle in range [-180, 180
  */
 double heading_resolve(double degrees);
 

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -726,6 +726,8 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 class BoatDialogBase : public wxDialog {
 private:
+  void CreateCursorInfoPanel(wxWindow* parent, wxSizer* parentSizer);
+
 protected:
   wxFlexGridSizer* m_fgSizer;
   wxSplitterWindow* m_splitter2;
@@ -763,6 +765,13 @@ protected:
   wxButton* m_bOpenBoat;
   wxButton* m_bSaveBoat;
   wxButton* m_bSaveAsBoat;
+
+  // Cursor information display
+  wxStaticText* m_stCursorWindAngle;
+  wxStaticText* m_stCursorWindSpeed;
+  wxStaticText* m_stCursorBoatSpeed;
+  wxStaticText* m_stCursorVMG;
+  wxStaticText* m_stCursorVMGAngle;
 
   // Virtual event handlers, overide them in your derived class
   virtual void OnMouseEventsPolarPlot(wxMouseEvent& event) { event.Skip(); }

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -4195,6 +4195,9 @@ BoatDialogBase::BoatDialogBase(wxWindow* parent, wxWindowID id,
 
   sbSizer31->Add(fgSizer92, 1, wxEXPAND, 5);
 
+  // Add cursor information panel using helper function
+  CreateCursorInfoPanel(m_panel21, sbSizer31);
+
   m_panel21->SetSizer(sbSizer31);
   m_panel21->Layout();
   sbSizer31->Fit(m_panel21);
@@ -4431,6 +4434,52 @@ BoatDialogBase::~BoatDialogBase() {
   m_bSaveAsBoat->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                             wxCommandEventHandler(BoatDialogBase::OnSaveAsBoat),
                             NULL, this);
+}
+
+void BoatDialogBase::CreateCursorInfoPanel(wxWindow* parent,
+                                           wxSizer* parentSizer) {
+  // Create sizer for the cursor info panel
+  wxStaticBoxSizer* cursorSizer =
+      new wxStaticBoxSizer(wxVERTICAL, parent, _("Cursor Information"));
+
+  // Create a grid sizer for the labels and values
+  wxFlexGridSizer* gridSizer = new wxFlexGridSizer(5, 2, 5, 10);
+  gridSizer->AddGrowableCol(1);
+
+  // Wind Angle
+  gridSizer->Add(new wxStaticText(parent, wxID_ANY, _("Wind Angle:")), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  m_stCursorWindAngle = new wxStaticText(parent, wxID_ANY, _("N/A"));
+  gridSizer->Add(m_stCursorWindAngle, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+
+  // Wind Speed
+  gridSizer->Add(new wxStaticText(parent, wxID_ANY, _("Wind Speed:")), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  m_stCursorWindSpeed = new wxStaticText(parent, wxID_ANY, _("N/A"));
+  gridSizer->Add(m_stCursorWindSpeed, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+
+  // Boat Speed
+  gridSizer->Add(new wxStaticText(parent, wxID_ANY, _("Boat Speed:")), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  m_stCursorBoatSpeed = new wxStaticText(parent, wxID_ANY, _("N/A"));
+  gridSizer->Add(m_stCursorBoatSpeed, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+
+  // VMG
+  gridSizer->Add(new wxStaticText(parent, wxID_ANY, _("VMG:")), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  m_stCursorVMG = new wxStaticText(parent, wxID_ANY, _("N/A"));
+  gridSizer->Add(m_stCursorVMG, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+
+  // VMG Angle
+  gridSizer->Add(new wxStaticText(parent, wxID_ANY, _("VMG Angle:")), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  m_stCursorVMGAngle = new wxStaticText(parent, wxID_ANY, _("N/A"));
+  gridSizer->Add(m_stCursorVMGAngle, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+
+  cursorSizer->Add(gridSizer, 1, wxEXPAND | wxALL, 5);
+
+  // Add the cursor info panel to the parent sizer
+  parentSizer->Add(cursorSizer, 0, wxEXPAND | wxALL, 5);
 }
 
 StatisticsDialogBase::StatisticsDialogBase(wxWindow* parent, wxWindowID id,


### PR DESCRIPTION
# Enhance the polar diagram

1. Each wind speed line has a unique color from a blue-to-red gradient, providing immediate visual feedback about wind speed magnitude.
2. Show tooltip with polar data.
3. Highlight the closest wind line with a thicker pen width.
4. Optimize the size of the polar when "Full Plot" is unchecked. Use as much space as is available in the polar panel. Previously it was optimized for the full polar plot.
5. Add panel showing the interpolated polar data at the cursor.
6. Render icon at the position of the cursor and matching VMG to make it clear what data is displayed in the new "Data at cursor" panel.
7. Show lines with the VMG angle.

# Screenshots

https://github.com/user-attachments/assets/2fdd020f-0788-4bf1-8d7c-e953891a89ff

