### PR TITLE
Thread-safe cache

### DIFF
--- a/include/ConstraintChecker.h
+++ b/include/ConstraintChecker.h
@@ -187,5 +187,6 @@ public:
 // Land cache management functions
 void log_cache_stats();
 void maintain_land_cache();
+void clear_land_cache();
 
 #endif


### PR DESCRIPTION
Address thread safety issues in the segment cache implementation that could lead to race conditions, data corruption, and crashes when multiple isochron propagations run concurrently.

This could happen if the user is triggering multiple isochrone propagations concurrently.