### PR TITLE
Route simplification

### DIFF
--- a/include/RouteSimplifier.h
+++ b/include/RouteSimplifier.h
@@ -275,6 +275,27 @@ private:
                                               double lon);
 
   /**
+   * Find the time at which a position was reached by searching through
+   * isochrones.
+   * @param position Position to find time for
+   * @param isochrones List of isochrones to search
+   * @return Time span from start, or -1 if not found
+   */
+  wxTimeSpan FindPositionTime(Position* position,
+                              const IsoChronList& isochrones) const;
+
+  /**
+   * Find time for a position using parent chain when not found in isochrones.
+   * @param position Position to find time for
+   * @param isochrones List of isochrones to search
+   * @param startTime Start time from first isochrone
+   * @return Time span from start, or -1 if not found
+   */
+  wxTimeSpan FindPositionTimeByParentChain(Position* position,
+                                           const IsoChronList& isochrones,
+                                           const wxDateTime& startTime) const;
+
+  /**
    * Find an alternate path through existing isochrones with fewer maneuvers.
    * @param isochrones List of existing isochrones
    * @param config Configuration with modified maneuver penalties


### PR DESCRIPTION
Replaced the unreliable `Contains()` geometric method for finding position times with a more robust approach that uses direct pointer comparison, geometric containment as fallback, and parent chain traversal for positions not found in isochrones. This handles variable time steps between isochrones and destination positions that may be interpolated within isochrone polygons rather than exact propagated points.

Fixes the "Failed to find segment duration" error that prevented route simplification from working.

<img width="779" alt="image" src="https://github.com/user-attachments/assets/1a10a349-2b78-4e37-8153-4fb9ba537f4a" />

<img width="732" alt="image" src="https://github.com/user-attachments/assets/7713b2e2-f1f6-4ce7-a61e-79d835983664" />

