### PR TITLE
Run unit tests in CI on macos

### DIFF
--- a/ci/circleci-build-macos-universal.sh
+++ b/ci/circleci-build-macos-universal.sh
@@ -72,9 +72,9 @@ if [[ -z "$CI" ]]; then
     exit 0
 fi
 
-# non-reproducible error on first invocation, seemingly tarball-conf-stamp
-# is not created as required.
-make -j12 && make test && make package || make package
+make -j$(nproc) 
+make test
+make package
 
 # Create the cached /usr/local archive
 if [ -n "$CI"  ]; then

--- a/ci/circleci-build-macos-universal.sh
+++ b/ci/circleci-build-macos-universal.sh
@@ -74,7 +74,7 @@ fi
 
 # non-reproducible error on first invocation, seemingly tarball-conf-stamp
 # is not created as required.
-make package || make package
+make -j12 && make test && make package || make package
 
 # Create the cached /usr/local archive
 if [ -n "$CI"  ]; then


### PR DESCRIPTION
This is a one-liner change to run unit tests in CI on macos. 

Why only macos? Because the other platforms have older versions of CMake which causes the installation of googletest to fail.  It's probably fixable, but hasn't been done yet.

This is not a permanent solution, as the file that has been changed (ci/circleci-build-macos-universal.sh) will be overwritten next time test_plugin gets upgraded, and this PR will be lost. But at least until then we have automatically run unit tests that will indicate regressions automatically.  And it's trivial to make this one-line change in the future again if needed. At some point we should figure out a way to enable per-plugin customization of test_plugin scripts, but I' don't believe that's possible today, and would probably require quite some work.