### PR TITLE
Add cmake target to display test code coverage

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15.0)
 
 project(weather_routing_pi_tests)
 set(CMAKE_CXX_STANDARD 17)
 message(STATUS "Building weather routing plugin tests")
+# make sure to use a Debug build, for coverage
+set(CMAKE_BUILD_TYPE "Debug")
 
-enable_testing ()
+include(CTest)
+include(GoogleTest)
 
 message(STATUS "Downloading and building gtest from source (if required)")
 # As per https://google.github.io/googletest/quickstart-cmake.html
@@ -38,51 +41,52 @@ set(TEST_SRC
     ${CMAKE_SOURCE_DIR}/src/PolygonRegion.cpp
     ${CMAKE_SOURCE_DIR}/src/Polar.cpp
     ${CMAKE_SOURCE_DIR}/src/zuFile.cpp
-   )
-   
-   add_executable(weather_routing_pi_tests ${TEST_SRC})
+)
+add_executable(${PROJECT_NAME} ${TEST_SRC})
 
-   # Uncomment include directories as needed - @todo tests should inherit this from main plugin
-   target_include_directories(weather_routing_pi_tests 
-        PRIVATE
-            ${CMAKE_SOURCE_DIR}/src
-   #         ${CMAKE_SOURCE_DIR}/opencpn-libs/api-18/include
-            ${CMAKE_SOURCE_DIR}/opencpn-libs/libtess2/include
-            ${CMAKE_SOURCE_DIR}/opencpn-libs/tinyxml/include
-   #         ${CMAKE_SOURCE_DIR}/opencpn-libs/plugin_dc/dc_utils/include
-   #         ${CMAKE_SOURCE_DIR}/opencpn-libs/jsonlib/include
-   #         ${CMAKE_SOURCE_DIR}/opencpn-libs/odapi
-   #         ${CMAKE_SOURCE_DIR}/opencpn-libs/pugixml
-            ${GTEST_INCLUDE_DIRS}
-            ${wxWidgets_INCLUDE_DIRS}
+# Compile and link with code coverage
+target_compile_options(${PROJECT_NAME} PRIVATE -coverage)
+target_link_options(${PROJECT_NAME} PRIVATE -coverage)
+
+# Uncomment include directories as needed - @todo tests should inherit this from main plugin
+target_include_directories(weather_routing_pi_tests 
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+#         ${CMAKE_SOURCE_DIR}/opencpn-libs/api-18/include
+        ${CMAKE_SOURCE_DIR}/opencpn-libs/libtess2/include
+        ${CMAKE_SOURCE_DIR}/opencpn-libs/tinyxml/include
+#         ${CMAKE_SOURCE_DIR}/opencpn-libs/plugin_dc/dc_utils/include
+#         ${CMAKE_SOURCE_DIR}/opencpn-libs/jsonlib/include
+#         ${CMAKE_SOURCE_DIR}/opencpn-libs/odapi
+#         ${CMAKE_SOURCE_DIR}/opencpn-libs/pugixml
+        ${GTEST_INCLUDE_DIRS}
+        ${wxWidgets_INCLUDE_DIRS}
+)
+
+# Uncomment required libraries as needed - @todo tests should inherit this from main plugin
+target_link_libraries(weather_routing_pi_tests 
+    PRIVATE 
+        GTest::gtest_main
+        ${wxWidgets_LIBRARIES}
+        ocpn::libtess2
+        ocpn::tinyxml
+        # ocpn::dc-utils
+        # ocpn::jsonlib
+        # ocpn::api_wx32
+        # ocpn::iso8211
+        # ocpn::json-schema-validator
+        # ocpn::wxsvg
+        ocpn::bzip2
+        ${ZLIB_LIBRARIES}
+)
+
+# Workaround as per https://discourse.cmake.org/t/how-to-get-an-lc-rpath-and-rpath-prefix-on-a-dylib-on-macos/5540/5
+# TODO: Quinton: Make this robust on non-Mac platforms.
+set_target_properties(weather_routing_pi_tests PROPERTIES
+    BUILD_RPATH "../lib"
+    INSTALL_RPATH "../lib"    
     )
    
-   # Uncomment required libraries as needed - @todo tests should inherit this from main plugin
-   target_link_libraries(weather_routing_pi_tests 
-       PRIVATE 
-           GTest::gtest_main
-           ${wxWidgets_LIBRARIES}
-           ocpn::libtess2
-           ocpn::tinyxml
-           # ocpn::dc-utils
-           # ocpn::jsonlib
-           # ocpn::api_wx32
-           # ocpn::iso8211
-           # ocpn::json-schema-validator
-           # ocpn::wxsvg
-           ocpn::bzip2
-           ${ZLIB_LIBRARIES}
-   )
-   
-   # Workaround as per https://discourse.cmake.org/t/how-to-get-an-lc-rpath-and-rpath-prefix-on-a-dylib-on-macos/5540/5
-   # TODO: Quinton: Make this robust on non-Mac platforms.
-   set_target_properties(weather_routing_pi_tests PROPERTIES
-       BUILD_RPATH "../lib"
-       INSTALL_RPATH "../lib"    
-       )
-   
-# Add the test
-add_test(NAME weather_routing_pi_tests COMMAND weather_routing_pi_tests)
 
 target_compile_definitions(weather_routing_pi_tests
     PUBLIC
@@ -90,5 +94,20 @@ target_compile_definitions(weather_routing_pi_tests
         TESTDATADIR="${CMAKE_CURRENT_LIST_DIR}/testdata"
 )
 
-include(GoogleTest)
-gtest_discover_tests(weather_routing_pi_tests)
+
+gtest_discover_tests(${PROJECT_NAME})
+
+# Create UNIT_UNDER_TEST_OBJECT_DIR variable
+set(OBJECT_DIR ${CMAKE_BINARY_DIR}/test/CMakeFiles/${PROJECT_NAME}.dir)
+set(UNIT_UNDER_TEST_OBJECT_DIR ${OBJECT_DIR}/__/src)
+message("-- Object files under test are assumed to be under: ${UNIT_UNDER_TEST_OBJECT_DIR}")
+
+# Create the coverage target. Run coverage tests with 'make coverage'
+add_custom_target(coverage
+    COMMAND ${CMAKE_MAKE_PROGRAM} test
+)
+
+# Add a custom command to the coverage target that runs gcov, only for src files
+add_custom_command(TARGET coverage
+    COMMAND gcov -n -s ${CMAKE_SOURCE_DIR}/src -r ${UNIT_UNDER_TEST_OBJECT_DIR}/*.o 
+)


### PR DESCRIPTION
This PR adds the ability to show test code coverage (as a percentage of lines of code).

### Overview:

1. When compiling and linking the unit test binary, additional '-coverage' flags are added to get the code, when executing, to generate code coverage data. This is in the form of a '.gcda' and a '.gcno' file per source file.
2. When running the unit tests, the above above data files are populated.
3. The new 'coverage' target runs the gcov tool (which is part of both the llvm and gcc tool chains) which analyses the above data files, and produces simple reports. of code coverage per source file.

### For example:

```
File 'Polar.cpp'
Lines executed:69.87% of 634

File 'PolygonRegion.cpp'
Lines executed:61.07% of 298
```

### To execute:

1. As usual, `mkdir -p build && cd build`
2. `cmake -DOCPN_BUILD_TEST=ON .. # Extra flag to enable building unit tests`
3. `make -j 12 # Compile and link, including the unit test binaries, with coverage enabled.`
4. `make coverage # Generate coverage reports - see above example.`

### Notes:

Because this is based on the de-facto standard 'gcov' tool, many further enhancements are relatively easy to add, for example more sophisticated coverage analyses, graphical reports, etc.  

### See also:

[gcov](https://en.wikipedia.org/wiki/Gcov)
[other tools supporting gcov](https://en.wikipedia.org/wiki/Gcov#Coverage_summaries)
[llvm-cov](https://llvm.org/docs/CommandGuide/llvm-cov.html)

cc @sebastien-rosset @rgleason 
 