### PR TITLE
Add a context menu to the positions list. Use standard formatting for latitude/longitude editing

### DIFF
--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -1108,10 +1108,8 @@ protected:
 
 public:
   wxTextCtrl* m_tName;
-  wxTextCtrl* m_tLatitudeDegrees;
-  wxTextCtrl* m_tLatitudeMinutes;
-  wxTextCtrl* m_tLongitudeDegrees;
-  wxTextCtrl* m_tLongitudeMinutes;
+  wxTextCtrl* m_tLatitude;
+  wxTextCtrl* m_tLongitude;
 
   NewPositionDialog(wxWindow* parent, wxWindowID id = wxID_ANY,
                     const wxString& title = _("Edit Weather Routing Position"),

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -735,28 +735,6 @@ void WeatherRouting::AddPosition(double lat, double lon) {
   if (pd.ShowModal() == wxID_OK) AddPosition(lat, lon, pd.GetValue(), false);
 }
 
-void WeatherRouting::AddPosition(const wxString& latitude_degrees,
-                                 const wxString& latitude_minutes,
-                                 const wxString& longitude_degrees,
-                                 const wxString& longitude_minutes,
-                                 wxString name, const bool suppress_prompt) {
-  double lat = 0, lon = 0, lat_minutes = 0, lon_minutes = 0;
-
-  latitude_degrees.ToDouble(&lat);
-  latitude_minutes.ToDouble(&lat_minutes);
-  lat_minutes = fabs(lat_minutes);
-  if (lat < 0) lat_minutes = -lat_minutes;
-  lat += lat_minutes / 60;
-
-  longitude_degrees.ToDouble(&lon);
-  longitude_minutes.ToDouble(&lon_minutes);
-  lon_minutes = fabs(lon_minutes);
-  if (lon < 0) lon_minutes = -lon_minutes;
-  lon += lon_minutes / 60;
-
-  AddPosition(lat, lon, std::move(name), suppress_prompt);
-}
-
 void WeatherRouting::AddPosition(double lat, double lon, wxString name,
                                  const bool suppress_prompt) {
   for (auto& it : RouteMap::Positions) {
@@ -1181,10 +1159,9 @@ void WeatherRouting::UpdateRoutePositionDialog() {
 void WeatherRouting::OnNewPosition(wxCommandEvent& event) {
   NewPositionDialog dlg(this);
   if (dlg.ShowModal() == wxID_OK) {
-    AddPosition(
-        dlg.m_tLatitudeDegrees->GetValue(), dlg.m_tLatitudeMinutes->GetValue(),
-        dlg.m_tLongitudeDegrees->GetValue(),
-        dlg.m_tLongitudeMinutes->GetValue(), dlg.m_tName->GetValue(), false);
+    AddPosition(fromDMM_Plugin(dlg.m_tLatitude->GetValue()),
+                fromDMM_Plugin(dlg.m_tLongitude->GetValue()),
+                dlg.m_tName->GetValue(), false);
   }
 }
 
@@ -1318,24 +1295,17 @@ void WeatherRouting::OnEditPosition() {
       dlg.m_tName->SetValue(p.Name);
       double degrees;
       double minutes = std::modf(p.lat, &degrees);
-      dlg.m_tLatitudeDegrees->SetValue(wxString::Format(wxT("%3.0f"), degrees));
-      dlg.m_tLatitudeMinutes->SetValue(
-          wxString::Format(wxT("%2.4f"), std::fabs(60 * minutes)));
-      minutes = std::modf(p.lon, &degrees);
-      dlg.m_tLongitudeDegrees->SetValue(
-          wxString::Format(wxT("%3.0f"), degrees));
-      dlg.m_tLongitudeMinutes->SetValue(
-          wxString::Format(wxT("%2.4f"), std::fabs(60 * minutes)));
+      dlg.m_tLatitude->SetValue(toSDMM_PlugIn(1, p.lat));
+      dlg.m_tLongitude->SetValue(toSDMM_PlugIn(2, p.lon));
       break;
     }
   }
 
   // Show dialog and store result
   if (dlg.ShowModal() == wxID_OK) {
-    AddPosition(
-        dlg.m_tLatitudeDegrees->GetValue(), dlg.m_tLatitudeMinutes->GetValue(),
-        dlg.m_tLongitudeDegrees->GetValue(),
-        dlg.m_tLongitudeMinutes->GetValue(), dlg.m_tName->GetValue(), true);
+    AddPosition(fromDMM_Plugin(dlg.m_tLatitude->GetValue()),
+                fromDMM_Plugin(dlg.m_tLongitude->GetValue()),
+                dlg.m_tName->GetValue(), true);
   }
 }
 

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -5769,64 +5769,27 @@ NewPositionDialog::NewPositionDialog(wxWindow* parent, wxWindowID id,
                            wxDefaultSize, 0);
   fgSizer119->Add(m_tName, 0, wxALL | wxEXPAND, 5);
 
-  fgSizer120->Add(fgSizer119, 1, wxEXPAND, 5);
-
-  wxFlexGridSizer* fgSizer122;
-  fgSizer122 = new wxFlexGridSizer(0, 5, 0, 0);
-  fgSizer122->SetFlexibleDirection(wxBOTH);
-  fgSizer122->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
-
   m_staticText142 = new wxStaticText(this, wxID_ANY, _("latitude"),
                                      wxDefaultPosition, wxDefaultSize, 0);
   m_staticText142->Wrap(-1);
-  fgSizer122->Add(m_staticText142, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  fgSizer119->Add(m_staticText142, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  m_tLatitudeDegrees = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
-                                      wxDefaultPosition, wxDefaultSize, 0);
-  fgSizer122->Add(m_tLatitudeDegrees, 1,
-                  wxALL | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5);
-
-  m_staticText143 = new wxStaticText(this, wxID_ANY, _("degrees"),
-                                     wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText143->Wrap(-1);
-  fgSizer122->Add(m_staticText143, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-
-  m_tLatitudeMinutes = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
-                                      wxDefaultPosition, wxDefaultSize, 0);
-  fgSizer122->Add(m_tLatitudeMinutes, 1,
-                  wxALL | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5);
-
-  m_staticText144 = new wxStaticText(this, wxID_ANY, _("minutes"),
-                                     wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText144->Wrap(-1);
-  fgSizer122->Add(m_staticText144, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  m_tLatitude = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                               wxDefaultSize, 0);
+  fgSizer119->Add(m_tLatitude, 1, wxALL | wxEXPAND | wxALIGN_CENTER_VERTICAL,
+                  5);
 
   m_staticText145 = new wxStaticText(this, wxID_ANY, _("longitude"),
                                      wxDefaultPosition, wxDefaultSize, 0);
   m_staticText145->Wrap(-1);
-  fgSizer122->Add(m_staticText145, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  fgSizer119->Add(m_staticText145, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  m_tLongitudeDegrees = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
-                                       wxDefaultPosition, wxDefaultSize, 0);
-  fgSizer122->Add(m_tLongitudeDegrees, 1,
-                  wxALL | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5);
+  m_tLongitude = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+                                wxDefaultPosition, wxDefaultSize, 0);
+  fgSizer119->Add(m_tLongitude, 1, wxALL | wxEXPAND | wxALIGN_CENTER_VERTICAL,
+                  5);
 
-  m_staticText146 = new wxStaticText(this, wxID_ANY, _("degrees"),
-                                     wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText146->Wrap(-1);
-  fgSizer122->Add(m_staticText146, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-
-  m_tLongitudeMinutes = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
-                                       wxDefaultPosition, wxDefaultSize, 0);
-  fgSizer122->Add(m_tLongitudeMinutes, 1,
-                  wxALL | wxEXPAND | wxALIGN_CENTER_VERTICAL, 5);
-
-  m_staticText147 = new wxStaticText(this, wxID_ANY, _("minutes"),
-                                     wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText147->Wrap(-1);
-  fgSizer122->Add(m_staticText147, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-
-  fgSizer120->Add(fgSizer122, 1, wxEXPAND, 5);
+  fgSizer120->Add(fgSizer119, 1, wxEXPAND, 5);
 
   m_sdbSizer4 = new wxStdDialogButtonSizer();
   m_sdbSizer4OK = new wxButton(this, wxID_OK);


### PR DESCRIPTION
Adds the context menu which didn't exist before.
Switches to the same method for input of latitude/longitude as in the Routemanager.