### PR TITLE
Fix breakage to macos build

### DIFF
--- a/ci/circleci-build-macos-universal.sh
+++ b/ci/circleci-build-macos-universal.sh
@@ -64,7 +64,7 @@ cmake \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
   -DOCPN_TARGET_TUPLE="darwin-wx32;10;universal" \
   -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
-#  -DOCPN_BUILD_TEST=ON \
+  -DOCPN_BUILD_TEST=ON \
   ..
 
 if [[ -z "$CI" ]]; then
@@ -73,9 +73,9 @@ if [[ -z "$CI" ]]; then
     exit 0
 fi
 
-# make -j 12 # Should ideally be 'make -j $(nproc)' but nproc is not installed in circleci VM
+make -j 12 # Should ideally be 'make -j $(nproc)' but nproc is not installed in circleci VM
 # See https://man7.org/linux/man-pages/man1/nproc.1.html - we could install GNU coreutils
-# make test
+make test
 # non-reproducible error on first invocation, seemingly tarball-conf-stamp
 # is not created as required.
 make package || make package


### PR DESCRIPTION
Fix breakage to macos build introduced by  https://github.com/rgleason/weather_routing_pi/commit/53a9c98f2f9c2976405a269bafdfa5f96f423707

See [breakage example](https://app.circleci.com/pipelines/github/quinton-hoole/weather_routing_pi/62/workflows/317be7e0-1275-4e1c-9eaf-ac6e4d0934b2/jobs/809)

