### PR TITLE
Remove user specific directory references from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,6 @@ endif (COMMAND cmake_policy)
 # set for vscode/vscodium
 set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 
-# point to your OpenCPN source and build:
-set(OCPN_SOURCE_DIR "C:/Users/fcgle/source/OpenCPN")
-set(OCPN_BUILD_DIR  "C:/Users/fcgle/source/OpenCPN/build")
-
 # define plugin name, owner and versions
 set(VERBOSE_NAME "WeatherRouting")
 set(COMMON_NAME "WeatherRouting")  # Search "getcommonname"in <plugin_pi>.cpp


### PR DESCRIPTION
These were presumably unintended user-specific edits originating from commit 603926f
Revert them.