### PR TITLE
Initialize timeseconds even though it is not used

### DIFF
--- a/src/RoutePoint.cpp
+++ b/src/RoutePoint.cpp
@@ -552,7 +552,8 @@ double RoutePoint::PropagateToPoint(double dlat, double dlon,
     ctw =
         weather_data.twdOverWater + heading; /* rotated relative to true wind */
 
-    double timeseconds;  // not used
+    double timeseconds = 0.0;  // Set to negative values for sail plan changes,
+                               // tacking and jibing
 
     if (!boat_data.GetBestPolarAndBoatSpeed(
             configuration, weather_data, heading, ctw, NAN /*parent_heading*/,


### PR DESCRIPTION
The variable timeseconds is not itialized, with a comment claiming that it is not used. In fact:

- GetBestPolarAndBoatSpeed() sets it to negative values for sail plan changes, tacking and jibing
- GetBoatSpeedForPolar() uses it to calculate BoatData.dist
- And BoatData.dist is not used (as claimed)

All the same, it is safer to initialize the variable, to avoid floating point exceptions (e.g. overflow or underflow).