### PR TITLE
Allow choosing waypoints as well as positions for weather route start…

### DIFF
--- a/include/ConfigurationDialog.h
+++ b/include/ConfigurationDialog.h
@@ -78,6 +78,10 @@ public:
   void AddSource(wxString name);
   void RemoveSource(wxString name);
   void ClearSources();
+  /// Fill combobox for start or end selection with all waypoints
+  void AddWaypoints(const bool toStart);
+  /// Fill combobox for start or end selection with all positions
+  void AddPositions(const bool toStart);
   void SetBoatFilename(wxString path);
 
   wxDateTime m_GribTimelineTime;
@@ -121,6 +125,9 @@ protected:
   }
   void OnStartFromBoat(wxCommandEvent& event);
   void OnStartFromPosition(wxCommandEvent& event);
+  void OnStartFromWaypoint(wxCommandEvent& event);
+  void OnEndAtPosition(wxCommandEvent& event);
+  void OnEndAtWaypoint(wxCommandEvent& event);
   void OnAvoidCyclones(wxCommandEvent& event);
   void OnUseMotor(wxCommandEvent& event);
   void OnAddDegreeStep(wxCommandEvent& event);

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -373,6 +373,7 @@ protected:
   /** Radio buttons for start selection */
   wxRadioButton* m_rbStartFromBoat;
   wxRadioButton* m_rbStartPositionSelection;
+  wxRadioButton* m_rbStartWaypointSelection;
   /** The starting point of the route. */
   wxComboBox* m_cStart;
   wxStaticText* m_staticText28;
@@ -419,6 +420,9 @@ protected:
   wxStaticText* m_staticText27;
   wxSpinCtrlDouble* m_sMaxSwellMeters;
   wxStaticText* m_staticText129;
+  /** Radio buttons for end selection */
+  wxRadioButton* m_rbEndPositionSelection;
+  wxRadioButton* m_rbEndWaypointSelection;
   /** The end point of the route. */
   wxComboBox* m_cEnd;
   wxSpinCtrl* m_sTimeStepHours;
@@ -475,6 +479,9 @@ protected:
   // Virtual event handlers, overide them in your derived class
   virtual void OnStartFromBoat(wxCommandEvent& event) { event.Skip(); }
   virtual void OnStartFromPosition(wxCommandEvent& event) { event.Skip(); }
+  virtual void OnStartFromWaypoint(wxCommandEvent& event) { event.Skip(); }
+  virtual void OnEndAtPosition(wxCommandEvent& event) { event.Skip(); }
+  virtual void OnEndAtWaypoint(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdate(wxCommandEvent& event) { event.Skip(); }
   virtual void OnUpdateDate(wxDateEvent& event) { event.Skip(); }
   virtual void OnUseCurrentTime(wxCommandEvent& event) { event.Skip(); }

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -138,6 +138,23 @@ bool RouteMapConfiguration::Update() {
       haveend = true;
     }
   }
+  wxArrayString waypoint_guids = GetWaypointGUIDArray();
+  PlugIn_Waypoint wp;
+
+  for (const auto& guid : waypoint_guids) {
+    GetSingleWaypoint(guid, &wp);
+
+    if (wp.m_MarkName == Start) {
+      StartLat = wp.m_lat;
+      StartLon = wp.m_lon;
+      havestart = true;
+    }
+    if (wp.m_MarkName == End) {
+      EndLat = wp.m_lat;
+      EndLon = wp.m_lon;
+      haveend = true;
+    }
+  }
   for (const auto& it : RouteMap::Positions) {
     if (StartType == RouteMapConfiguration::START_FROM_POSITION &&
         Start == it.Name) {

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1249,12 +1249,20 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
                            wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
   m_rbStartPositionSelection =
-      new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Start position"),
+      new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Position"),
                         wxDefaultPosition, wxDefaultSize);
   m_rbStartPositionSelection->SetToolTip(
       _("Select a predefined position as the starting point"));
   m_rbStartPositionSelection->SetValue(true);  // Default to position selection
   startSelectionSizer->Add(m_rbStartPositionSelection, 0,
+                           wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+  m_rbStartWaypointSelection =
+      new wxRadioButton(sbStart->GetStaticBox(), wxID_ANY, _("Waypoint"),
+                        wxDefaultPosition, wxDefaultSize);
+  m_rbStartWaypointSelection->SetToolTip(
+      _("Select a waypoint as the starting point"));
+  startSelectionSizer->Add(m_rbStartWaypointSelection, 0,
                            wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
   fgSizer60->Add(startSelectionSizer, 0, wxEXPAND, 5);
@@ -1474,6 +1482,35 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   wxStaticBoxSizer* sbEnd;
   sbEnd = new wxStaticBoxSizer(new wxStaticBox(m_pBasic, wxID_ANY, _("End")),
                                wxVERTICAL);
+
+  wxFlexGridSizer* fgSizer61;
+  fgSizer61 = new wxFlexGridSizer(0, 1, 0, 0);
+  fgSizer61->AddGrowableCol(0);
+  fgSizer61->SetFlexibleDirection(wxBOTH);
+  fgSizer61->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+  // Add radio button group for end selection
+  wxBoxSizer* endSelectionSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  m_rbEndPositionSelection =
+      new wxRadioButton(sbEnd->GetStaticBox(), wxID_ANY, _("Position"),
+                        wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  m_rbEndPositionSelection->SetToolTip(
+      _("Select a predefined position as the end point"));
+  m_rbEndPositionSelection->SetValue(true);  // Default to position selection
+  endSelectionSizer->Add(m_rbEndPositionSelection, 0,
+                         wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+  m_rbEndWaypointSelection =
+      new wxRadioButton(sbEnd->GetStaticBox(), wxID_ANY, _("Waypoint"),
+                        wxDefaultPosition, wxDefaultSize);
+  m_rbEndWaypointSelection->SetToolTip(_("Select a waypoint as the end point"));
+  endSelectionSizer->Add(m_rbEndWaypointSelection, 0,
+                         wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+  fgSizer61->Add(endSelectionSizer, 0, wxEXPAND, 5);
+
+  sbEnd->Add(fgSizer61, 1, wxEXPAND | wxALL, 5);
 
   m_cEnd =
       new wxComboBox(sbEnd->GetStaticBox(), wxID_ANY, wxEmptyString,
@@ -2279,6 +2316,10 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(ConfigurationDialogBase::OnStartFromPosition), NULL,
       this);
+  m_rbStartWaypointSelection->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnStartFromWaypoint), NULL,
+      this);
   m_cStart->Connect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                     wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
                     NULL, this);
@@ -2462,6 +2503,14 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sMaxSwellMeters->Connect(
       wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+  m_rbEndPositionSelection->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnEndAtPosition), NULL,
+      this);
+  m_rbEndWaypointSelection->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnEndAtWaypoint), NULL,
+      this);
   m_cEnd->Connect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                   wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
                   NULL, this);
@@ -2893,6 +2942,10 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(ConfigurationDialogBase::OnStartFromPosition), NULL,
       this);
+  m_rbStartWaypointSelection->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnStartFromWaypoint), NULL,
+      this);
   m_cStart->Disconnect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                        wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
                        NULL, this);
@@ -3077,6 +3130,14 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
   m_sMaxSwellMeters->Disconnect(
       wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+  m_rbEndPositionSelection->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnEndAtPosition), NULL,
+      this);
+  m_rbEndWaypointSelection->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnEndAtWaypoint), NULL,
+      this);
   m_cEnd->Disconnect(wxEVT_COMMAND_COMBOBOX_SELECTED,
                      wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
                      NULL, this);


### PR DESCRIPTION
Modify the weather routing configuration dialog to allow choosing between positions and waypoints for the start and end of a route.