### PR TITLE
Optimize DegreeSteps

### DIFF
--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -562,7 +562,7 @@ struct RouteMapConfiguration {
   /**
    * Collection of angular steps used for vessel propagation calculations.
    *
-   * This list contains the discrete angular steps (in degrees) that represent
+   * This vector contains the discrete angular steps (in degrees) that represent
    * the possible headings relative to the true wind direction that the vessel
    * can take during propagation. These angles are pre-computed based on the
    * FromDegree, ToDegree, and ByDegrees configuration parameters.
@@ -578,7 +578,7 @@ struct RouteMapConfiguration {
    * complexity. Smaller step sizes provide more precise routing but require
    * more calculations.
    */
-  std::list<double> DegreeSteps;
+  std::vector<double> DegreeSteps;
   /** The latitude of the starting position, in decimal degrees. */
   double StartLat;
   /** The longitude of the starting position, in decimal degrees. */

--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -242,10 +242,8 @@ bool Position::Propagate(IsoRouteList& routelist,
     bearing2 = heading_resolve(parent_bearing + configuration.MaxSearchAngle);
   }
 
-  for (auto it = configuration.DegreeSteps.begin();
-       it != configuration.DegreeSteps.end(); it++) {
+  for (const double& twa : configuration.DegreeSteps) {
     double timeseconds = configuration.UsedDeltaTime;
-    double twa = heading_resolve(*it);
     double ctw =
         weather_data.twdOverWater + twa; /* rotated relative to true wind */
 

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -205,13 +205,13 @@ bool RouteMapConfiguration::Update() {
     while (step <= ToDegree + 1E-3) {  // Avoid missing the last step by a tiny
                                        // fraction, due to rounding errors
       DegreeSteps.push_back(step);
-      if (step > 0 && step < 180) DegreeSteps.push_back(360 - step);
+      if (step > 0.0 && step < 180.0) DegreeSteps.push_back(-step);
       step += ByDegrees;
     }
   } else {
     DegreeSteps.push_back(0.);
   }
-  DegreeSteps.sort();
+  std::sort(DegreeSteps.begin(), DegreeSteps.end());
 
   return true;
 }


### PR DESCRIPTION
Make DegreeSteps more efficient

1. Use vector instead of list
2. Create steps in range of ]-180, 180] instead of calling heading_resolve in the main loop
3. Use twa as loop variable instead of dereferencing an iterator