### PR TITLE
Fix different-typed variables sharing a common scale  on weather routing plot

### DIFF
--- a/src/PlotDialog.cpp
+++ b/src/PlotDialog.cpp
@@ -275,8 +275,8 @@ void PlotDialog::GetScale() {
   for (int i = 0; i < 2; i++) {
     for (int j = i + 1; j < 3; j++) {
       // Use the same scale if variables are of the same type
-      if (GetType(cVariable[i]->GetSelection()) ==
-          GetType(cVariable[j]->GetSelection())) {
+      if (GetType(GetVariableEnumFromIndex(cVariable[i]->GetSelection())) ==
+          GetType(GetVariableEnumFromIndex(cVariable[j]->GetSelection()))) {
         m_minvalue[i] = m_minvalue[j] = wxMin(m_minvalue[i], m_minvalue[j]);
         m_maxvalue[i] = m_maxvalue[j] = wxMax(m_maxvalue[i], m_maxvalue[j]);
       }


### PR DESCRIPTION
(cherry picked from commit accb68152beaa0f86d9f6bb3aa3f4318a77901f0)

See https://github.com/rgleason/weather_routing_pi/issues/584
and https://github.com/quinton-hoole/weather_routing_pi/pull/23