### PR TITLE
Fix routing table confuses local time with UTC

### DIFF
--- a/src/RoutingTablePanel.cpp
+++ b/src/RoutingTablePanel.cpp
@@ -1556,8 +1556,9 @@ void RoutingTablePanel::UpdateSummary() {
       useLocalTime ? summary.startTime.FromUTC() : summary.startTime;
   wxDateTime displayEndTime =
       useLocalTime ? summary.endTime.FromUTC() : summary.endTime;
-  m_departureText->SetLabel(displayStartTime.Format("%Y-%m-%d %H:%M %Z"));
-  m_arrivalText->SetLabel(displayEndTime.Format("%Y-%m-%d %H:%M %Z"));
+  std::string timeFormat = useLocalTime? "%Y-%m-%d %H:%M %Z" : "%Y-%m-%d %H:%M UTC"; 
+  m_departureText->SetLabel(displayStartTime.Format(timeFormat.c_str()));
+  m_arrivalText->SetLabel(displayEndTime.Format(timeFormat.c_str()));
 #endif
 
   m_distanceText->SetLabel(FormatDistance(summary.totalDistance));


### PR DESCRIPTION
(cherry picked from commit b96c9611ee6398fc6c551052374344913bd10b25)

See https://github.com/quinton-hoole/weather_routing_pi/pull/21
and https://github.com/rgleason/weather_routing_pi/issues/456
