### PR TITLE
std::sort() is in <algorithm>.  Include it.

### DIFF
--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -68,6 +68,7 @@
 #include <math.h>
 #include <list>
 #include <map>
+#include <algorithm>
 
 #include "Utilities.h"
 #include "ConstraintChecker.h"


### PR DESCRIPTION
(cherry picked from commit 4113dd778ebfde61fc6de5eaa33d60f4befb5be3)
See https://github.com/quinton-hoole/weather_routing_pi/pull/25

The missing include breaks the build on Debian sometimes.