### PR TITLE
Remove unnecessary and confusing pairs of ToUTC() and FromUTC() calls

### DIFF
--- a/.github/workflows/bldwin32-rdeb.yml
+++ b/.github/workflows/bldwin32-rdeb.yml
@@ -1,0 +1,44 @@
+name: bldwin32-rdeb
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  build-win32:
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: MSVC dev cmd (x86)
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+
+      - name: Install wxWidgets via vcpkg (x86-windows)
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgTriplet: x86-windows
+          runVcpkgInstall: true
+          vcpkgJsonGlob: vcpkg.json
+
+      - name: Configure (CMake, Win32, RelWithDebInfo)
+        shell: pwsh
+        run: |
+          cmake -S . -B build `
+            -G "Visual Studio 17 2022" -A Win32 -T v143 `
+            -DOCPN_TARGET=MSVC `
+            -DwxWidgets_ROOT_DIR="${env:VCPKG_INSTALLED_DIR}\x86-windows" `
+            -DwxWidgets_LIB_DIR="${env:VCPKG_INSTALLED_DIR}\x86-windows\lib" `
+            -DCMAKE_TOOLCHAIN_FILE="${env:VCPKG_ROOT}\scripts\buildsystems\vcpkg.cmake"
+
+      - name: Build (RelWithDebInfo)
+        run: cmake --build build --target package --config RelWithDebInfo
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-win32-rdeb-package
+          path: build/**

--- a/include/ReportDialog.h
+++ b/include/ReportDialog.h
@@ -41,7 +41,7 @@ protected:
   void OnClose(wxCommandEvent& event) { Hide(); }
 
 private:
-  wxDateTime DisplayedTime(wxDateTime t);
+  wxDateTime::TimeZone DisplayedTimeZone();
   wxString FormatTime(wxDateTime t);
   WeatherRouting& m_WeatherRouting;
 };

--- a/include/SettingsDialog.h
+++ b/include/SettingsDialog.h
@@ -72,6 +72,9 @@ public:
 
   static const wxString column_names[];
 
+  // Return UTC or local time, depending on m_cbUseLocalTime
+  wxDateTime::TimeZone GetTimeZone() const;
+
 
 #ifdef __WXMSW__
   // ========== Windows-Only: Address Space Monitoring ==========
@@ -114,4 +117,3 @@ public:
 };
 
 #endif
-

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -82,7 +82,7 @@ void ConfigurationDialog::OnGribTime(wxCommandEvent& event) {
 }
 
 void ConfigurationDialog::OnCurrentTime(wxCommandEvent& event) {
-  SetStartDateTime(wxDateTime::Now().ToUTC());
+  SetStartDateTime(wxDateTime::Now());  // Local time converted to UTC
   Update();
 }
 
@@ -267,16 +267,17 @@ void ConfigurationDialog::SetConfigurations(
   std::list<RouteMapConfiguration>::iterator it = configurations.begin();
 
   const bool ult =
-      m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue();
-#define STARTTIME (ult ? it->StartTime.FromUTC() : it->StartTime)
+      m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->IsChecked();
 
   // Populate date/time from the first configuration safely
   if (it != configurations.end()) {
     // Date part: only set if valid (avoid MSW assert), otherwise set "none"
     // only when the control supports wxDP_ALLOWNONE
-    wxDateTime dateVal = STARTTIME.GetDateOnly();
+    wxDateTime dateVal = it->StartTime.GetDateOnly();  // No conversion here
     wxSize s(m_dpStartDate->GetSize());
     if (dateVal.IsValid()) {
+      // SetValue() assumes dateVal is UTC and converts to local time for GUI
+      if (!ult) dateVal = dateVal.ToUTC();  // Undo the FromUTC() in SetValue()
       m_dpStartDate->SetValue(dateVal);
       m_dpStartDate->SetForegroundColour(wxColour(0, 0, 0));
     } else if (m_dpStartDate->GetWindowStyle() & wxDP_ALLOWNONE) {
@@ -288,9 +289,11 @@ void ConfigurationDialog::SetConfigurations(
 
     // Time part: only set if valid (time control usually requires a valid
     // value)
-    wxDateTime timeVal = STARTTIME;
+    wxDateTime timeVal = it->StartTime;
     wxSize s2(m_tpTime->GetSize());
     if (timeVal.IsValid()) {
+      // SetValue() assumes timeVal is UTC and converts to local time for GUI
+      if (!ult) timeVal = timeVal.ToUTC();  // Undo the FromUTC() in SetValue()
       m_tpTime->SetValue(timeVal);
       m_tpTime->SetForegroundColour(wxColour(0, 0, 0));
     }  // else leave control unchanged
@@ -517,9 +520,12 @@ void ConfigurationDialog::OnResetAdvanced(wxCommandEvent& event) {
 }
 
 void ConfigurationDialog::SetStartDateTime(wxDateTime datetime) {
+  // datetime is passed as UTC
   if (datetime.IsValid()) {
-    if (m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
-      datetime = datetime.FromUTC();
+    // SetValue() for both pickers assumes that datetime is UTC and converts
+    // to local time for display in the GUI
+    if (!m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->IsChecked())
+      datetime = datetime.ToUTC();  // Undo the FromUTC() in SetValue()
 
     m_dpStartDate->SetValue(datetime);
     m_tpTime->SetValue(datetime);
@@ -582,77 +588,42 @@ void ConfigurationDialog::Update() {
 
     if (NO_EDITED_CONTROLS ||
         std::find(m_edited_controls.begin(), m_edited_controls.end(),
-                  (wxObject*)m_dpStartDate) != m_edited_controls.end()) {
-      if (!m_dpStartDate->GetDateCtrlValue().IsValid()) continue;
-      // We must preserve the time in case only date but not time, is being
-      // changed by the user... configuration.StartTime is UTC, m_dpStartDate
-      // Local or UTC so adjust
-	// Replace each occurrence of:
-	//    wxDateTime time = configuration.StartTime;
-	// with the defensive version below.
-	
-	wxDateTime time = configuration.StartTime;
-	if (!time.IsValid())
-	{
-		// Defensive fallback: avoid passing an invalid wxDateTime to SetValue().
-		// Policy choices:
-		//  - Use current time to keep UI populated: time = wxDateTime::Now();
-		//  - Skip calling SetValue() for invalid dates (requires branch at call site)
-		//  - Use SetStartDateTime(time) which shows a warning (not ideal in bulk updates)
-		//
-		// Here we choose to fall back to now to avoid the wxCHECK abort.
-		time = wxDateTime::Now();
-	}
-      if (m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
-        time = time.FromUTC();
-
-      wxDateTime date = m_dpStartDate->GetDateCtrlValue();
-      // ... and add it afterwards
-      date.SetHour(time.GetHour());
-      date.SetMinute(time.GetMinute());
-      date.SetSecond(time.GetSecond());
-
-      if (m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
-        date = date.ToUTC();
-
-      configuration.StartTime = date;
-      m_dpStartDate->SetForegroundColour(wxColour(0, 0, 0));
-    }
-
-    if (NO_EDITED_CONTROLS ||
+                  (wxObject*)m_dpStartDate) != m_edited_controls.end() ||
         std::find(m_edited_controls.begin(), m_edited_controls.end(),
                   (wxObject*)m_tpTime) != m_edited_controls.end()) {
-      // must use correct data on UTC conversion to preserve Daylight Savings
-      // Time changes across dates
+      if (!m_dpStartDate->GetDateCtrlValue().IsValid()) continue;
 
-	// Replace each occurrence of:
-	//    wxDateTime time = configuration.StartTime;
-	// with the defensive version below.
-
-	wxDateTime time = configuration.StartTime;
-	if (!time.IsValid())
-	{
-		// Defensive fallback: avoid passing an invalid wxDateTime to SetValue().
-		// Policy choices:
-		//  - Use current time to keep UI populated: time = wxDateTime::Now();
-		//  - Skip calling SetValue() for invalid dates (requires branch at call site)
-		//  - Use SetStartDateTime(time) which shows a warning (not ideal in bulk updates)
-		//
-		// Here we choose to fall back to now to avoid the wxCHECK abort.
-		time = wxDateTime::Now();
-}
-      if (m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
-        time = time.FromUTC();
-
-      time.SetHour(m_tpTime->GetTimeCtrlValue().GetHour());
-      time.SetMinute(m_tpTime->GetTimeCtrlValue().GetMinute());
-      time.SetSecond(m_tpTime->GetTimeCtrlValue().GetSecond());
-
-      if (m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
-        time = time.ToUTC();
+      /*
+       * GetDateCtrlValue() and GetTimeCtrlValue() assume that the entered time
+       * is local time and convert to UTC for internal storage
+       * GetHour() etc. convert internal UTC value to local time
+       * wxDateTime() constructor assumes input in local time and converts to
+       * UTC for internal storage
+       * Therefore we must undo one ToUTC() conversion if the GUI option has
+       * been set to use UTC
+       * Note: There will be one hour error if the switch to/from DST happens
+       * in between these calls
+       * Note: GetTimeCtrlValue() sets the date part to Jan 1st of the current
+       *       year, therefore calling ToUTC() on it is not DST-safe
+       */
+      wxDateTime ctrl_date = m_dpStartDate->GetDateCtrlValue();
+      wxDateTime ctrl_time = m_tpTime->GetTimeCtrlValue();
+      wxDateTime time(ctrl_date.GetDay(), ctrl_date.GetMonth(),
+                      ctrl_date.GetYear(), ctrl_time.GetHour(),
+                      ctrl_time.GetMinute(), ctrl_time.GetSecond());
+      if (!time.IsValid())
+        time = wxDateTime::Now();  // Local time converted to UTC
+      else if (!m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->IsChecked())
+        time = time.FromUTC();  // Undo extra conversion
 
       configuration.StartTime = time;
-      m_tpTime->SetForegroundColour(wxColour(0, 0, 0));
+
+      if (std::find(m_edited_controls.begin(), m_edited_controls.end(),
+                    (wxObject*)m_dpStartDate) != m_edited_controls.end())
+        m_dpStartDate->SetForegroundColour(wxColour(0, 0, 0));
+      else if (std::find(m_edited_controls.begin(), m_edited_controls.end(),
+                         (wxObject*)m_tpTime) != m_edited_controls.end())
+        m_tpTime->SetForegroundColour(wxColour(0, 0, 0));
     }
 
     if (!m_tBoat->GetValue().empty()) {

--- a/src/ReportDialog.cpp
+++ b/src/ReportDialog.cpp
@@ -170,15 +170,12 @@ void ReportDialog::SetRouteMapOverlays(
   m_htmlConfigurationReport->SetPage(page);
 }
 
-wxDateTime ReportDialog::DisplayedTime(wxDateTime t) {
-  wxDateTime display_time = t;
-  if (m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
-    display_time = t.FromUTC();
-  return display_time;
+wxDateTime::TimeZone ReportDialog::DisplayedTimeZone() {
+  return m_WeatherRouting.m_SettingsDialog.GetTimeZone();
 }
 
 wxString ReportDialog::FormatTime(wxDateTime t) {
-  wxString r = DisplayedTime(t).Format(_T("%x %X"));
+  wxString r = t.Format(_T("%x %X"), DisplayedTimeZone());
 #if 0
     // XXX add this?
     if(m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue())
@@ -292,8 +289,8 @@ void ReportDialog::GenerateRoutesReport() {
         if (it == sort_by_start.end()) break;
 
         RouteMapOverlay* r = it->second;
-        wxDateTime s = DisplayedTime(r->StartTime());
-        wxDateTime e = DisplayedTime(r->EndTime());
+        wxDateTime s = r->StartTime();
+        wxDateTime e = r->EndTime();
         // merge downwind
         for (; it != sort_by_start.end(); it++) {
           RouteMapOverlay* r = it->second;
@@ -306,7 +303,8 @@ void ReportDialog::GenerateRoutesReport() {
           first_print = false;
         else
           page += _(" and ");
-        page += s.Format(_T("%d %B ")) + _("to") + e.Format(_T(" %d %B"));
+        page += s.Format(_T("%d %B "), DisplayedTimeZone()) + _("to") +
+                e.Format(_T(" %d %B"), DisplayedTimeZone());
       }
     }
 
@@ -400,7 +398,7 @@ void ReportDialog::GenerateRoutesReport() {
         if (!*it2) continue;
         if (!first) page += _(" and ");
         first = false;
-        page += DisplayedTime((*it2)->StartTime()).Format(_T("%x"));
+        page += ((*it2)->StartTime()).Format(_T("%x"), DisplayedTimeZone());
 
         if (++it2 == cyclone_safe_routes.end()) break;
 
@@ -409,7 +407,7 @@ void ReportDialog::GenerateRoutesReport() {
         while (*it2 && ++it2 != cyclone_safe_routes.end());
 
         it2--;
-        page += _(" to ") + DisplayedTime((*it2)->StartTime()).Format(_T("%x"));
+        page += _(" to ") + ((*it2)->StartTime()).Format(_T("%x"), DisplayedTimeZone());
       }
     }
   cyclonesfailed:;

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -1435,7 +1435,6 @@ void RouteMapOverlay::GetLLBounds(double& latmin, double& latmax,
 
 void RouteMapOverlay::RequestGrib(wxDateTime time) {
   Json::Value v;
-  time = time.FromUTC();
   v["Day"] = time.GetDay();
   v["Month"] = time.GetMonth();
   v["Year"] = time.GetYear();

--- a/src/RoutingTablePanel.cpp
+++ b/src/RoutingTablePanel.cpp
@@ -791,8 +791,6 @@ void RoutingTablePanel::PopulateTable() {
 
   // Get configuration for formatting
   RouteMapConfiguration configuration = m_RouteMap->GetConfiguration();
-  bool useLocalTime =
-      m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue();
 
   // Fill the grid with data
   int row = 0;
@@ -817,14 +815,13 @@ void RoutingTablePanel::PopulateTable() {
 #else
     // Fallback for earlier API versions - format time with proper timezone
     // label
-    wxDateTime displayTime = data.time;
+    bool useLocalTime =
+      m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->IsChecked();
+
     if (useLocalTime) {
-      displayTime = data.time.FromUTC();
-    }
-    if (useLocalTime) {
-      timeString = displayTime.Format("%Y-%m-%d %H:%M %Z");
+      timeString = data.time.Format("%Y-%m-%d %H:%M %Z", wxDateTime::Local);
     } else {
-      timeString = displayTime.Format("%Y-%m-%d %H:%M UTC");
+      timeString = data.time.Format("%Y-%m-%d %H:%M UTC", wxDateTime::UTC);
     }
 #endif
     // ETA column with time-of-day background color
@@ -1539,22 +1536,21 @@ void RoutingTablePanel::UpdateSummary() {
     return;
   }
 
-  bool useLocalTime =
-      m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->GetValue();
-
   // Update summary text controls with calculated data
 #if OCPN_API_VERSION_MAJOR > 1 || \
     (OCPN_API_VERSION_MAJOR == 1 && OCPN_API_VERSION_MINOR >= 20)
   m_departureText->SetLabel(toUsrDateTimeFormat_Plugin(summary.startTime));
   m_arrivalText->SetLabel(toUsrDateTimeFormat_Plugin(summary.endTime));
 #else
-  wxDateTime displayStartTime =
-      useLocalTime ? summary.startTime.FromUTC() : summary.startTime;
-  wxDateTime displayEndTime =
-      useLocalTime ? summary.endTime.FromUTC() : summary.endTime;
-  std::string timeFormat = useLocalTime? "%Y-%m-%d %H:%M %Z" : "%Y-%m-%d %H:%M UTC"; 
-  m_departureText->SetLabel(displayStartTime.Format(timeFormat.c_str()));
-  m_arrivalText->SetLabel(displayEndTime.Format(timeFormat.c_str()));
+  bool useLocalTime =
+      m_WeatherRouting.m_SettingsDialog.m_cbUseLocalTime->IsChecked();
+
+  std::string timeFormat =
+    useLocalTime? "%Y-%m-%d %H:%M %Z" : "%Y-%m-%d %H:%M UTC";
+  m_departureText->SetLabel(summary.startTime.Format(
+      timeFormat.c_str(), m_WeatherRouting.m_SettingsDialog.GetTimeZone()));
+  m_arrivalText->SetLabel(summary.endTime.Format(
+      timeFormat.c_str(), m_WeatherRouting.m_SettingsDialog.GetTimeZone()));
 #endif
 
   m_distanceText->SetLabel(FormatDistance(summary.totalDistance));

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -708,3 +708,9 @@ if there are multiple processors\n");
                        wxOK | wxICON_INFORMATION);
   mdlg.ShowModal();
 }
+
+wxDateTime::TimeZone SettingsDialog::GetTimeZone() const {
+  return m_cbUseLocalTime->IsChecked()
+    ? wxDateTime::Local
+    : wxDateTime::UTC;
+}

--- a/src/WeatherDataProvider.cpp
+++ b/src/WeatherDataProvider.cpp
@@ -32,13 +32,11 @@
 extern Json::Value g_ReceivedJSONMsg;
 extern wxString g_ReceivedMessage;
 
-static Json::Value RequestGRIB(const wxDateTime& t, const wxString& what,
+static Json::Value RequestGRIB(const wxDateTime& time, const wxString& what,
                                double lat, double lon) {
   Json::Value error;
   Json::Value v;
   Json::FastWriter writer;
-  // brain dead wx is expecting time in local time
-  wxDateTime time = t.FromUTC();
   if (!time.IsValid()) return error;
 
   v["Day"] = time.GetDay();

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -892,7 +892,7 @@ void WeatherRouting::UpdateColumns() {
 
       if (i == STARTTIME || i == ENDTIME) {
         name += " (";
-        if (m_SettingsDialog.m_cbUseLocalTime->GetValue())
+        if (m_SettingsDialog.m_cbUseLocalTime->IsChecked())
           name += _("local");
         else
           name += "UTC";
@@ -971,12 +971,9 @@ void WeatherRouting::UpdateCursorPositionDialog() {
     CursorPositionDialogMessage(dlg, _("Cursor outside computed route map"));
     return;
   }
-  wxDateTime display_time = rmo->GetLastCursorTime();
 
-  if (m_SettingsDialog.m_cbUseLocalTime->GetValue())
-    display_time = display_time.FromUTC();
-
-  dlg.m_stTime->SetLabel(display_time.Format("%x %H:%M"));
+  dlg.m_stTime->SetLabel(rmo->GetLastCursorTime().Format(
+      "%x %H:%M", m_SettingsDialog.GetTimeZone()));
 
   RouteMapConfiguration configuration = rmo->GetConfiguration();
   auto latStr = toSDMM_PlugIn(NEflag::LAT, p->lat, Precision::HI);
@@ -1064,11 +1061,8 @@ void WeatherRouting::UpdateRoutePositionDialog() {
   wxDateTime startTime = configuration.StartTime;
   wxDateTime cursorTime = data.time;
 
-  if (m_SettingsDialog.m_cbUseLocalTime->GetValue()) {
-    startTime = startTime.FromUTC();
-    cursorTime = data.time.FromUTC();
-  }
-  dlg.m_stTime->SetLabel(cursorTime.Format("%x %H:%M"));
+  dlg.m_stTime->SetLabel(
+      cursorTime.Format("%x %H:%M", m_SettingsDialog.GetTimeZone()));
 
   wxString duration = calculateTimeDelta(startTime, cursorTime);
   dlg.m_stDuration->SetLabel(duration);
@@ -2643,18 +2637,15 @@ void WeatherRoute::Update(WeatherRouting* wr, bool stateonly) {
             : _("From Boat");
     UseCurrentTime = configuration.UseCurrentTime ? _("true") : _("false");
     wxDateTime starttime = configuration.StartTime;
-    if (wr->m_SettingsDialog.m_cbUseLocalTime->GetValue())
-      starttime = starttime.FromUTC();
-    StartTime = starttime.Format("%x %H:%M");
+    StartTime =
+        starttime.Format("%x %H:%M", wr->m_SettingsDialog.GetTimeZone());
 
     End = configuration.End;
 
     wxDateTime endtime = routemapoverlay->EndTime();
-    if (endtime.IsValid()) {
-      if (wr->m_SettingsDialog.m_cbUseLocalTime->GetValue())
-        endtime = endtime.FromUTC();
-      EndTime = endtime.Format("%x %H:%M");
-    } else
+    if (endtime.IsValid())
+      EndTime = endtime.Format("%x %H:%M", wr->m_SettingsDialog.GetTimeZone());
+    else
       EndTime = "N/A";
 
     // REFACTORING
@@ -3090,12 +3081,10 @@ void WeatherRouting::SaveAsTrack(RouteMapOverlay& routemapoverlay) {
   }
 
   PlugIn_Track* newPath = new PlugIn_Track;
-  wxDateTime display_time = routemapoverlay.StartTime();
-  if (m_SettingsDialog.m_cbUseLocalTime->GetValue())
-    display_time = display_time.FromUTC();
-
-  newPath->m_NameString =
-      _("Weather Route ") + " (" + display_time.Format("%x %H:%M") + ")";
+  newPath->m_NameString = _("Weather Route ") + " (" +
+                          routemapoverlay.StartTime().Format(
+                              "%x %H:%M", m_SettingsDialog.GetTimeZone()) +
+                          ")";
 
   // XXX double check time is really end time, not start time off by one.
   RouteMapConfiguration c = routemapoverlay.GetConfiguration();
@@ -3148,12 +3137,10 @@ void WeatherRouting::SaveAsRoute(RouteMapOverlay& routemapoverlay) {
   }
 
   PlugIn_Route_Ex* newRoute = new PlugIn_Route_Ex();
-  wxDateTime display_time = routemapoverlay.StartTime();
-  if (m_SettingsDialog.m_cbUseLocalTime->GetValue())
-    display_time = display_time.FromUTC();
-
-  newRoute->m_NameString =
-      _("Weather Route ") + " (" + display_time.Format("%x %H:%M") + ")";
+  newRoute->m_NameString = _("Weather Route ") + " (" +
+                           routemapoverlay.StartTime().Format(
+                               "%x %H:%M", m_SettingsDialog.GetTimeZone()) +
+                           ")";
 
   RouteMapConfiguration c = routemapoverlay.GetConfiguration();
   newRoute->m_StartString = c.Start;
@@ -3210,12 +3197,9 @@ void WeatherRouting::ExportRoute(RouteMapOverlay& routemapoverlay) {
   SimpleRoute new_route;
   new_route.m_GUID = GetNewGUID();
 
-  wxDateTime display_time = routemapoverlay.StartTime();
-  if (m_SettingsDialog.m_cbUseLocalTime->GetValue())
-    display_time = display_time.FromUTC();
-
   new_route.m_RouteNameString =
-      "WXRoute_" + display_time.Format("%m-%d-%y_%H-%M");
+      "WXRoute_" + routemapoverlay.StartTime().Format(
+                       "%m-%d-%y_%H-%M", m_SettingsDialog.GetTimeZone());
   new_route.m_RouteNameString += "_" + c.Start + "_" + c.End;
 
   new_route.m_RouteStartString = c.Start;
@@ -3653,11 +3637,8 @@ void WeatherRouting::SaveSimplifiedRoute(
 
       if (closestData && minDistance < 0.1) {  // Within 0.1 nm
         // Add time information to waypoint description
-        wxDateTime time = closestData->time;
-        if (m_SettingsDialog.m_cbUseLocalTime->GetValue())
-          time = time.FromUTC();
-
-        waypoint->m_MarkDescription = time.Format("%x %H:%M");
+        waypoint->m_MarkDescription = closestData->time.Format(
+            "%x %H:%M", m_SettingsDialog.GetTimeZone());
 
         // Optionally add other information (wind, etc.)
         waypoint->m_MarkDescription += wxString::Format(

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -860,7 +860,7 @@ void WeatherRouting::AddRoute(wxString& GUID) {
     configuration = DefaultConfiguration();
 
   configuration.RouteGUID = GUID;
-  configuration.StartTime = wxDateTime::Now();
+  configuration.StartTime = wxDateTime::Now();  // Local time converted to UTC
   configuration.DeltaTime = 3600;
 
   if (!AddConfiguration(configuration)) return;
@@ -2269,8 +2269,10 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure) {
             AttributeBool(e, "UseCurrentTime", false);
         if (configuration.UseCurrentTime) {
           // The current time will be overridden when the route is computed.
-          configuration.StartTime = wxDateTime::Now().ToUTC();
+          configuration.StartTime =
+              wxDateTime::Now();  // Local time converted to UTC
         } else {
+          // Note: StartDate and StartTime are stored as UTC
           wxDateTime date;
           date.ParseISODate(wxString::FromUTF8(e->Attribute("StartDate")));
           wxDateTime time;
@@ -3347,7 +3349,7 @@ void WeatherRouting::Start(RouteMapOverlay* routemapoverlay) {
   }
   if (configuration.UseCurrentTime) {
     // Use the current time
-    configuration.StartTime = wxDateTime::Now().ToUTC();
+    configuration.StartTime = wxDateTime::Now();  // Local time converted to UTC
     configUpdated = true;
   }
   if (configUpdated) {
@@ -3543,7 +3545,7 @@ RouteMapConfiguration WeatherRouting::DefaultConfiguration() {
   } else
     configuration.StartLat = 0, configuration.StartLon = 0;
 
-  configuration.StartTime = wxDateTime::Now();
+  configuration.StartTime = wxDateTime::Now();  // Local time converted to UTC
   configuration.DeltaTime = 3600;
 
   if (RouteMap::Positions.size() >= 2) {

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -3098,7 +3098,8 @@ void WeatherRouting::SaveAsTrack(RouteMapOverlay& routemapoverlay) {
     PlugIn_Waypoint* newPoint = new PlugIn_Waypoint(
         it.lat, heading_resolve(it.lon), "circle", _("Weather Route Point"));
 
-    newPoint->m_CreateTime = it.time;
+    // TODO Remove ToUTC() as soon as bug #621 is fixed in main program
+    newPoint->m_CreateTime = it.time.ToUTC();
     newPath->pWaypointList->Append(newPoint);
   }
 
@@ -3108,7 +3109,8 @@ void WeatherRouting::SaveAsTrack(RouteMapOverlay& routemapoverlay) {
     PlugIn_Waypoint* newPoint =
         new PlugIn_Waypoint(p->lat, heading_resolve(p->lon), "circle",
                             _("Weather Route Destination"));
-    newPoint->m_CreateTime = routemapoverlay.EndTime();
+    // TODO Remove ToUTC() as soon as bug #621 is fixed in main program
+    newPoint->m_CreateTime = routemapoverlay.EndTime().ToUTC();
     newPath->pWaypointList->Append(newPoint);
   }
 
@@ -3154,7 +3156,8 @@ void WeatherRouting::SaveAsRoute(RouteMapOverlay& routemapoverlay) {
     PlugIn_Waypoint_Ex* newPoint = new PlugIn_Waypoint_Ex(
         it.lat, heading_resolve(it.lon), "circle", _("Weather Route Point"));
     // newPoint->m_PlannedSpeed = it.sog;
-    newPoint->m_CreateTime = it.time;
+    // TODO Remove ToUTC() as soon as bug #621 is fixed in main program
+    newPoint->m_CreateTime = it.time.ToUTC();
     newRoute->pWaypointList->Append(newPoint);
   }
 
@@ -3164,7 +3167,8 @@ void WeatherRouting::SaveAsRoute(RouteMapOverlay& routemapoverlay) {
     PlugIn_Waypoint_Ex* newPoint =
         new PlugIn_Waypoint_Ex(p->lat, heading_resolve(p->lon), "circle",
                                _("Weather Route Destination"));
-    newPoint->m_CreateTime = routemapoverlay.EndTime();
+    // TODO Remove ToUTC() as soon as bug #621 is fixed in main program
+    newPoint->m_CreateTime = routemapoverlay.EndTime().ToUTC();
     newRoute->pWaypointList->Append(newPoint);
   }
 

--- a/src/weather_routing_pi.cpp
+++ b/src/weather_routing_pi.cpp
@@ -423,13 +423,13 @@ void weather_routing_pi::SetPluginMessage(wxString& message_id,
     if (v["Day"].asInt() != -1) {
       wxDateTime time;
 
+      // Assumes local time and converts to UTC
       time.Set(v["Day"].asInt(), (wxDateTime::Month)v["Month"].asInt(),
                v["Year"].asInt(), v["Hour"].asInt(), v["Minute"].asInt(),
                v["Second"].asInt());
 
       if (m_pWeather_Routing && time.IsValid()) {
-        m_pWeather_Routing->m_ConfigurationDialog.m_GribTimelineTime =
-            time.ToUTC();
+        m_pWeather_Routing->m_ConfigurationDialog.m_GribTimelineTime = time;
         //            m_pWeather_Routing->m_ConfigurationDialog.m_cbUseGrib->Enable();
         RequestRefresh(m_parent_window);
       }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-routing-pi",
   "version-string": "0.0.0",
-  "builtin-baseline":"https://github.com/microsoft/vcpkg/commit/26283ac5e8a068561a718ce18b169bfad84c7dab",
+  "builtin-baseline":"26283ac5e8a068561a718ce18b169bfad84c7dab",
   "dependencies": ["wxwidgets"]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-routing-pi",
   "version-string": "0.0.0",
-  "builtin-baseline": "26283ac5e8a068561a718ce18b169bfad84c7dab",
+  "builtin-baseline":"https://github.com/microsoft/vcpkg/commit/26283ac5e8a068561a718ce18b169bfad84c7dab",
   "dependencies": ["wxwidgets"]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "weather-routing-pi",
+  "version-string": "0.0.0",
+  "builtin-baseline": "26283ac5e8a068561a718ce18b169bfad84c7dab",
+  "dependencies": ["wxwidgets"]
+}


### PR DESCRIPTION
Background: wxDateTime stores the time as a signed number of milliseconds since the Epoch. The internal representation is time zone independent (always in GMT). `wxDateTime::Now()` returns the object corresponding to the current time in local time zone, represented internally in UTC. All setter and getter functions that use date parts (day, month, year, hour, minute, second) assume that input and output are in the local timezone, and convert them to/from UTC.

`RouteMapConfiguration::StartTime` is UTC according to `ConfigurationDialog::Update()`. Therefore it is wrong to call `ToUTC()` in the following locations:
- `WeatherRouting::Start()`
- `ConfigurationDialog::OnCurrentTime()`
- `ConfigurationDialog::Update()`
- `WeatherRouting::OpenXML()`

Call chain for `GRIB_VALUES_REQUEST`
- `WeatherDataProvider::GetGribWind()` uses configuration.time which is in UTC according to RouteMap.h
- WeaterDataProvider.cpp function `RequestGRIB()` extracts the date parts from wxDateTime, thus converting to local time
- `grib_pi::SetPluginMessage()` constructs wxDateTime from date parts, thus converting back to UTC for internal storage
- `GRIBUICtrlBar::getTimeInterpolatedValues()` uses `wxDateTime::GetTicks()` to convert to seconds since the epoch (no timezone conversion happens here)
  This time is compared with:
- `GribRecord::getRecordCurrentDate()` which returns the field curDate
- According to the Grib plugin, file GribRecord.h, the field `curDate` is "Unix timestamp of when this forecast is valid".

Therefore the conversion `time = t.fromUTC()` in `WeaterDataProvider.cpp::RequestGRIB()` is wrong.

Call chain `GRIB_TIMELINE_RECORD_REQUEST` -> `GRIB_TIMELINE_RECORD`
- `RouteMap::Reset()` initializes `m_NewTime` with `m_Configuration.StartTime` which is UTC according to `ConfigurationDialog::Update()`
- `WeatherRouting::OnComputationTimer()` gets time from `RouteMapOverlay::NewTime()`
- `RouteMapOverlay::RequestGrib()` extracts parts, thus converting to local time
- `grib_pi::SetPluginMessage()` constructs wxDateTime from date parts, thus converting back to UTC for internal storage
- `GRIBUICtrlBar::GetTimeLineRecordSet()` compares time with `GribRecordSet::m_Reference_Time`
- According to GribRecordSet.h, the field `m_Reference_Time` is "seconds since the epoch"
- `weather_routing_pi::SetPluginMessage()` uses the raw grib data with no time zone conversion

Therefore the conversion `time = time.FromUTC()` in `RouteMapOverlay::RequestGrib()` is wrong

Call chain for `GRIB_TIMELINE_REQUEST` -> `GRIB_TIMELINE`
- `grib_pi::SetPluginMessage()` calls `SendTimelineMessage()` with `GRIBUICtrlBar::TimelineTime()` or `wxDateTime::Now()`
  - `Now()` takes current local time and converts to UTC
  - `TimelineTime()` is UTC
- `SendTimelineMessage()` extracts the date parts from wxDateTime, thus converting to local time
- `weather_routing_pi::SetPluginMessage()` assumes local time, converts to UTC and stores in `ConfigurationDialog::m_GribTimelineTime`
- `ConfigurationDialog::m_GribTimelineTime` is UTC

Therefore conversion `time.ToUTC()` in `weather_routing_pi::SetPluginMessage()` is wrong