### PR TITLE
Make time step reduction factor configurable in the GUI

### DIFF
--- a/include/RouteMap.h
+++ b/include/RouteMap.h
@@ -257,6 +257,13 @@ struct RouteMapConfiguration {
   double DeltaTime;
   /** Time in seconds between propagations. */
   double UsedDeltaTime;
+  /**
+   * A reduction factor is applied when leaving source or approaching
+   * destination. The time step will be multiplied by this factor.
+   * This is the minimum value, which the reduction factor will have
+   * exactly at the source and just before the destination.
+   */
+  double MinReductionFactor;
 
   /** The polars of the boat, used for the route calculation. */
   Boat boat;

--- a/include/WeatherRoutingUI.h
+++ b/include/WeatherRoutingUI.h
@@ -30,6 +30,7 @@
 #include <wx/stattext.h>
 #include <wx/clrpicker.h>
 #include <wx/spinctrl.h>
+#include <wx/slider.h>
 #include <wx/checkbox.h>
 #include <wx/scrolwin.h>
 #include <wx/checklst.h>
@@ -470,6 +471,11 @@ protected:
   wxStaticText* m_staticText241;
   wxSpinCtrlDouble* m_sSafetyMarginLand;
   wxStaticText* m_staticText1211;
+  wxStaticText* m_staticText242;
+  wxCheckBox* m_cbAdaptiveTimestep;
+  wxSlider* m_sMinimumTimestep;
+  wxStaticText* m_tMinimumTimestep;
+  wxStaticText* m_staticText1212;
   wxStaticText* m_staticText113;
   wxStaticText* m_staticText115;
   wxStaticText* m_staticText117;

--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -434,6 +434,18 @@ void ConfigurationDialog::SetConfigurations(
   SET_SPIN(CycloneDays);
   SET_SPIN_DOUBLE(SafetyMarginLand);
 
+  if ((*it).MinReductionFactor < 1.0 && (*it).MinReductionFactor >= 0.1) {
+    m_cbAdaptiveTimestep->SetValue(true);
+    m_sMinimumTimestep->SetRange(10,
+                                 100);  // Allow 90 steps between min and max
+    double mins = (*it).DeltaTime / 60 * (*it).MinReductionFactor;
+    m_sMinimumTimestep->SetValue(std::round((*it).MinReductionFactor * 100.0));
+    m_tMinimumTimestep->SetLabel(wxString::FromDouble(mins, 2));
+  } else {
+    m_cbAdaptiveTimestep->SetValue(false);
+  }
+  m_sMinimumTimestep->Enable(m_cbAdaptiveTimestep->GetValue());
+
   SET_CHECKBOX(DetectLand);
   SET_CHECKBOX(DetectBoundary);
   SET_CHECKBOX(Currents);
@@ -520,6 +532,8 @@ void ConfigurationDialog::OnResetAdvanced(wxCommandEvent& event) {
   m_sJibingTime->SetValue(0);
   m_sSailPlanChangeTime->SetValue(0);
   m_sSafetyMarginLand->SetValue(0.);
+  m_cbAdaptiveTimestep->SetValue(false);
+  m_sMinimumTimestep->Enable(false);
 
   m_sFromDegree->SetValue(0);
   m_sToDegree->SetValue(180);
@@ -696,6 +710,16 @@ void ConfigurationDialog::Update() {
     GET_SPIN(CycloneMonths);
     GET_SPIN(CycloneDays);
     GET_SPIN(SafetyMarginLand);
+    if (m_cbAdaptiveTimestep->IsChecked()) {
+      m_sMinimumTimestep->SetRange(10, 100);  // Allow 90 steps from min to max
+      configuration.MinReductionFactor = m_sMinimumTimestep->GetValue() / 100.0;
+      m_tMinimumTimestep->SetLabel(wxString::FromDouble(
+          configuration.DeltaTime / 60.0 * configuration.MinReductionFactor,
+          2));
+    } else {
+      configuration.MinReductionFactor = 1.0;
+    }
+    m_sMinimumTimestep->Enable(m_cbAdaptiveTimestep->IsChecked());
 
     GET_CHECKBOX(DetectLand);
     GET_CHECKBOX(DetectBoundary);

--- a/src/RouteMap.cpp
+++ b/src/RouteMap.cpp
@@ -90,6 +90,7 @@ weather_routing_pi* RouteMapConfiguration::s_plugin_instance = nullptr;
 
 RouteMapConfiguration::RouteMapConfiguration()
     : StartType(START_FROM_POSITION),
+      MinReductionFactor(0.1),
       UpwindEfficiency(1.),
       DownwindEfficiency(1.),
       NightCumulativeEfficiency(1.),
@@ -426,8 +427,7 @@ double RouteMap::DetermineDeltaTime() {
   double maxDistFromStart = -INFINITY;
 
   const double proximityThreshold = 40.0;  // nautical miles
-  const double minReductionFactor =
-      0.1;  // Minimum reduction factor (10% of normal time step)
+  const double& minReductionFactor = m_Configuration.MinReductionFactor;
   // Will be adjusted based on distances
   double startReductionFactor = 1.0;
   double endReductionFactor = 1.0;
@@ -468,17 +468,19 @@ double RouteMap::DetermineDeltaTime() {
     // Calculate gradual reduction factors
 
     // For starting point: gradually increase from minReductionFactor to 1.0
-    if (maxDistFromStart < proximityThreshold) {
+    if (minReductionFactor < 1.0 && maxDistFromStart < proximityThreshold) {
       // As we move away from the start, the time step increases.
       startReductionFactor =
-          minReductionFactor + (0.9 * maxDistFromStart / proximityThreshold);
+          minReductionFactor +
+          ((1.0 - minReductionFactor) * maxDistFromStart / proximityThreshold);
     }
 
     // For destination: gradually decrease from 1.0 to minReductionFactor
-    if (minDistToEnd < proximityThreshold) {
+    if (minReductionFactor < 1.0 && minDistToEnd < proximityThreshold) {
       // As we get closer to the destination, the time step decreases.
       endReductionFactor =
-          minReductionFactor + (0.9 * minDistToEnd / proximityThreshold);
+          minReductionFactor +
+          ((1.0 - minReductionFactor) * minDistToEnd / proximityThreshold);
     }
 
     // Apply the minimum of both reduction factors.

--- a/src/WeatherRouting.cpp
+++ b/src/WeatherRouting.cpp
@@ -2291,6 +2291,8 @@ bool WeatherRouting::OpenXML(wxString filename, bool reportfailure) {
 
         configuration.End = wxString::FromUTF8(e->Attribute("End"));
         configuration.DeltaTime = AttributeDouble(e, "dt", 0);
+        configuration.MinReductionFactor =
+            AttributeDouble(e, "MinReductionFactor", 0.1);
 
         configuration.boatFileName = wxString::FromUTF8(e->Attribute("Boat"));
         if (!wxFileName::FileExists(configuration.boatFileName)) {
@@ -2448,6 +2450,7 @@ void WeatherRouting::SaveXML(wxString filename) {
     }
     c->SetAttribute("End", configuration.End.mb_str());
     c->SetAttribute("dt", configuration.DeltaTime);
+    c->SetAttribute("MinReductionFactor", configuration.MinReductionFactor);
 
     c->SetAttribute("Boat", configuration.boatFileName.ToUTF8());
 

--- a/src/WeatherRoutingUI.cpp
+++ b/src/WeatherRoutingUI.cpp
@@ -1913,6 +1913,62 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   sbMotor->Add(fgSizerMotor, 1, wxEXPAND, 5);
   fgSizerLeftColumn->Add(sbMotor, 0, wxEXPAND | wxALL, 5);
 
+  // Adaptive timestep section
+  wxStaticBoxSizer* sbAdaptiveTimestep;
+  sbAdaptiveTimestep = new wxStaticBoxSizer(
+      new wxStaticBox(m_pAdvanced, wxID_ANY, _("Adaptive timestep")),
+      wxVERTICAL);
+
+  wxFlexGridSizer* fgSizerAdaptiveTS;
+  fgSizerAdaptiveTS = new wxFlexGridSizer(0, 1, 0, 0);
+  fgSizerAdaptiveTS->SetFlexibleDirection(wxBOTH);
+  fgSizerAdaptiveTS->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+  m_cbAdaptiveTimestep = new wxCheckBox(sbAdaptiveTimestep->GetStaticBox(),
+                                        wxID_ANY, _("Use adaptive timestep"),
+                                        wxDefaultPosition, wxDefaultSize, 0);
+  m_cbAdaptiveTimestep->SetToolTip(
+      _("Reduce or increase the timestep depending on certain conditions."));
+  fgSizerAdaptiveTS->Add(m_cbAdaptiveTimestep, 0, wxALL, 5);
+
+  wxFlexGridSizer* fgSizer11512;
+  fgSizer11512 = new wxFlexGridSizer(1, 0, 0, 0);
+  fgSizer11512->SetFlexibleDirection(wxBOTH);
+  fgSizer11512->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+  m_staticText242 =
+      new wxStaticText(sbAdaptiveTimestep->GetStaticBox(), wxID_ANY,
+                       _("Initial and final time step at source / destination"),
+                       wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText242->Wrap(-1);
+  fgSizer11512->Add(m_staticText242, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+  m_sMinimumTimestep =
+      new wxSlider(sbAdaptiveTimestep->GetStaticBox(), wxID_ANY, 10, 1, 100);
+  m_sMinimumTimestep->SetToolTip(
+      _("When leaving the source, this is the initial time step. It will be "
+        "increased up to the full timestep. Similarly, on approaching the "
+        "destination, the full timestep will be slowly reduced to the "
+        "initial value"));
+  m_sMinimumTimestep->Enable(false);
+  fgSizer11512->Add(m_sMinimumTimestep, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+  m_tMinimumTimestep =
+      new wxStaticText(sbAdaptiveTimestep->GetStaticBox(), wxID_ANY, "10.00",
+                       wxDefaultPosition, wxDefaultSize, 0);
+  m_tMinimumTimestep->Wrap(-1);
+  fgSizer11512->Add(m_tMinimumTimestep, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  m_staticText1212 =
+      new wxStaticText(sbAdaptiveTimestep->GetStaticBox(), wxID_ANY, _("min"),
+                       wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText1212->Wrap(-1);
+  fgSizer11512->Add(m_staticText1212, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+  fgSizerAdaptiveTS->Add(fgSizer11512, 1, wxEXPAND, 5);
+
+  sbAdaptiveTimestep->Add(fgSizerAdaptiveTS, 1, wxEXPAND, 5);
+  fgSizerLeftColumn->Add(sbAdaptiveTimestep, 0, wxEXPAND | wxALL, 5);
+
   // Grid container for "Options", "Courses", "Polar Efficiency" sections
   wxFlexGridSizer* fgSizer109;
   fgSizer109 = new wxFlexGridSizer(3, 0, 0, 0);
@@ -2907,6 +2963,12 @@ ConfigurationDialogBase::ConfigurationDialogBase(wxWindow* parent,
   m_sSafetyMarginLand->Connect(
       wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+  m_cbAdaptiveTimestep->Connect(
+      wxEVT_COMMAND_CHECKBOX_CLICKED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnUpdate), NULL, this);
+  m_sMinimumTimestep->Connect(
+      wxEVT_SLIDER, wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
+      NULL, this);
   m_sUpwindEfficiency->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
@@ -3542,6 +3604,12 @@ ConfigurationDialogBase::~ConfigurationDialogBase() {
   m_sSafetyMarginLand->Disconnect(
       wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);
+  m_cbAdaptiveTimestep->Disconnect(
+      wxEVT_COMMAND_CHECKBOX_CLICKED,
+      wxCommandEventHandler(ConfigurationDialogBase::OnUpdate), NULL, this);
+  m_sMinimumTimestep->Disconnect(
+      wxEVT_SLIDER, wxCommandEventHandler(ConfigurationDialogBase::OnUpdate),
+      NULL, this);
   m_sUpwindEfficiency->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
       wxSpinEventHandler(ConfigurationDialogBase::OnUpdateSpin), NULL, this);


### PR DESCRIPTION
The timestep reduction factor when leaving the source or arriving at the destination was fixed at 0.1. It is now an advanced option in the new "Adaptive timestep" section of the configuration. 