### PR TITLE
Fix real-wr-refactor-engine-ui compilation

### DIFF
--- a/BUILD_NOTES.md
+++ b/BUILD_NOTES.md
@@ -1,0 +1,43 @@
+# Build notes
+
+- Target branch: `real-wr-refactor-engine-ui`
+- Base commit: `bc8a8a4bab49073ebe8319cead431111843dac2c` (`Update TP1.0.362`)
+- Target repository: `https://github.com/rgleason/weather_routing_pi.git`
+- OpenCPN source inspected read-only: `/home/paul/src/OpenCPN`
+- OpenCPN build inspected read-only: `/home/paul/src/OpenCPN/build`
+- OpenCPN version supplied/verified: 5.15.0
+- Local OpenCPN plugin API: 1.21, from `/home/paul/src/OpenCPN/include/ocpn_plugin.h`
+- Plugin-declared and bundled build API: 1.18
+- Compiler: GCC/G++ 16.1.1
+- CMake: 4.3.4
+- wxWidgets: 3.2.10, GTK 3
+
+## Build commands
+
+```sh
+git submodule update --init --recursive
+cmake -S . -B build-isolated -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-isolated -j4
+cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release
+cmake --build build-release -j4
+```
+
+## Result
+
+Both Debug and clean Release standalone builds completed successfully. The
+Release output is `build-release/libweather_routing_pi.so`.
+
+The compile fixes restore the missing `BoatDialog::OnUpPolar` function name,
+use an unambiguous `wxString` fallback in the route filter, and include
+`<cstdint>` before direct inclusion of the bundled OpenCPN API header. No
+OpenCPN source/build tree or bundled `opencpn-libs` source was modified.
+
+## Remaining limitations
+
+- This verifies standalone compilation and linking only; the plugin was not
+  installed into or runtime-tested with OpenCPN.
+- Existing compiler warnings (primarily member initialization order and
+  signed/unsigned comparisons) remain unchanged because they do not block the
+  build and are outside this focused compile fix.
+- Runtime compatibility with OpenCPN plugin API 1.21 remains to be verified;
+  this branch still declares and builds against plugin API 1.18.

--- a/include/ConfigurationBatchDialog.h
+++ b/include/ConfigurationBatchDialog.h
@@ -21,6 +21,7 @@
 #define _WEATHER_ROUTING_BATCH_DIALOG_H_
 
 #include <wx/fileconf.h>
+#include <cstdint>
 #include <ocpn_plugin.h>
 
 #include "WeatherRoutingUI.h"

--- a/include/RoutingTablePanel.h
+++ b/include/RoutingTablePanel.h
@@ -24,6 +24,7 @@
 #include <map>
 
 #include "WeatherRoutingUI.h"
+#include <cstdint>
 #include "ocpn_plugin.h"
 
 class WeatherRouting;

--- a/include/weather_routing_pi.h
+++ b/include/weather_routing_pi.h
@@ -77,6 +77,7 @@
 
 #define ABOUT_AUTHOR_URL "http://seandepagnier.users.sourceforge.net"
 
+#include <cstdint>
 #include "ocpn_plugin.h"
 #include "pidc.h"
 #include "qtstylesheet.h"

--- a/src/BoatDialog.cpp
+++ b/src/BoatDialog.cpp
@@ -1287,7 +1287,7 @@ void BoatDialog::OnUpdatePlot() {
   RefreshPlots();
 }
 // Legacy UI
-void BoatDialog:: (wxCommandEvent& event) {
+void BoatDialog::OnUpPolar(wxCommandEvent& event) {
   long index = SelectedPolar();
   if (index < 1) return;
 

--- a/src/ConstraintChecker.cpp
+++ b/src/ConstraintChecker.cpp
@@ -37,6 +37,7 @@
 #include "Utilities.h"
 
 #include "georef.h"
+#include <cstdint>
 #include "ocpn_plugin.h"
 
 // Quantize to 1e-5 deg (about 1m)

--- a/src/FilterRoutesDialog.cpp
+++ b/src/FilterRoutesDialog.cpp
@@ -94,7 +94,7 @@ void FilterRoutesDialog::ApplyFilters() {
           // wxDateTime ? string
           value = (*it)->StartTime.IsValid()
                       ? (*it)->StartTime.FormatISOCombined(' ')
-                      : wxEmptyString;
+                      : wxString();
           break;
 
         case END:

--- a/src/LineBufferOverlay.cpp
+++ b/src/LineBufferOverlay.cpp
@@ -20,6 +20,7 @@
 #include <wx/wx.h>
 #include <wx/glcanvas.h>
 
+#include <cstdint>
 #include "ocpn_plugin.h"
 #include "LineBufferOverlay.h"
 

--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -24,6 +24,7 @@
 #include "Utilities.h"
 
 #include "georef.h"
+#include <cstdint>
 #include "ocpn_plugin.h"
 
 /* sufficient for routemap uses only.. is this faster than below? if not, remove

--- a/src/ReportDialog.cpp
+++ b/src/ReportDialog.cpp
@@ -26,6 +26,7 @@
 #include <math.h>
 #include <time.h>
 
+#include <cstdint>
 #include "ocpn_plugin.h"
 
 #include "Utilities.h"

--- a/src/RouteMapOverlay.cpp
+++ b/src/RouteMapOverlay.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <string>
 
+#include <cstdint>
 #include "ocpn_plugin.h"
 #include "pidc.h"
 #include "json/json.h"

--- a/src/RoutePoint.cpp
+++ b/src/RoutePoint.cpp
@@ -24,6 +24,7 @@
 #include "RouteMap.h"
 #include "Utilities.h"
 #include "SunCalculator.h"
+#include <cstdint>
 #include "ocpn_plugin.h"
 #include "georef.h"
 

--- a/src/RouteSimplifier.cpp
+++ b/src/RouteSimplifier.cpp
@@ -19,6 +19,7 @@
 
 #include <wx/wx.h>
 
+#include <cstdint>
 #include "ocpn_plugin.h"
 #include "Utilities.h"
 #include "Boat.h"

--- a/src/WeatherDataProvider.cpp
+++ b/src/WeatherDataProvider.cpp
@@ -27,6 +27,7 @@
 #include "WeatherDataProvider.h"
 #include "RouteMap.h"
 #include "Utilities.h"
+#include <cstdint>
 #include "ocpn_plugin.h"
 
 #define distance(X, Y) sqrt((X) * (X) + (Y) * (Y))  // much faster than hypot

--- a/src/icons.cpp
+++ b/src/icons.cpp
@@ -9,6 +9,7 @@
 wxBitmap* _img_WeatherRouting;
 
 #ifdef PLUGIN_USE_SVG
+#include <cstdint>
 #include "ocpn_plugin.h"
 wxString _svg_weather_routing;
 wxString _svg_weather_routing_rollover;


### PR DESCRIPTION
This draft PR contains a focused set of compile fixes for `real-wr-refactor-engine-ui`.

Changes:
- Restore the accidentally removed `BoatDialog::OnUpPolar` function name.
- Resolve an ambiguous wxWidgets `wxString` conditional.
- Include `<cstdint>` before direct uses of the bundled OpenCPN API header.
- Add build and verification notes.

Verification:
- Base commit: `bc8a8a4bab49073ebe8319cead431111843dac2c`
- Standalone Debug build: passed
- Clean standalone Release build: passed
- `git diff --check`: passed
- Patch application against the base commit: passed

The local OpenCPN source used for compatibility context is 5.15.0 with plugin API 1.21. This branch still declares and builds against plugin API 1.18, so runtime loading in OpenCPN 5.15.0 has not yet been verified. Existing nonfatal warnings are unchanged.

Rick: could you please test this locally and confirm whether this is the preferred target branch? The PR is left as a draft until runtime compatibility and intended direction are confirmed.