### PR TITLE
Keep full time to fix errors in timezone conversion

### DIFF
--- a/src/ConfigurationDialog.cpp
+++ b/src/ConfigurationDialog.cpp
@@ -286,7 +286,7 @@ void ConfigurationDialog::SetConfigurations(
   if (it != configurations.end()) {
     // Date part: only set if valid (avoid MSW assert), otherwise set "none"
     // only when the control supports wxDP_ALLOWNONE
-    wxDateTime dateVal = it->StartTime.GetDateOnly();  // No conversion here
+    wxDateTime dateVal = it->StartTime;  // No conversion here
     wxSize s(m_dpStartDate->GetSize());
     if (dateVal.IsValid()) {
       // SetValue() assumes dateVal is UTC and converts to local time for GUI


### PR DESCRIPTION
Using GetDateOnly() sets the time component to 00:00:00. When doing the timezone conversions on this value, an error is introduced. For example, in CEST time zone, the date will go back one day because local time is 2 hours ahead of UTC. 00:00:00 will convert to 22:00:00 one day earlier.